### PR TITLE
Hopsworks 2465 Secrets- Update Radio component

### DIFF
--- a/src/components/radio/index.tsx
+++ b/src/components/radio/index.tsx
@@ -9,11 +9,21 @@ import styles from './radio-styles';
 
 export interface RadioProps extends Omit<RebassRadioProps, 'css'> {
   label?: string;
+  addtionalText?: string;
 }
 
 const Radio: FC<RadioProps> = forwardRef(
   (
-    { label, name, id, disabled, onChange, checked, ...props }: RadioProps,
+    {
+      label,
+      addtionalText,
+      name,
+      id,
+      disabled,
+      onChange,
+      checked,
+      ...props
+    }: RadioProps,
     ref,
   ) => (
     <Flex
@@ -39,6 +49,11 @@ const Radio: FC<RadioProps> = forwardRef(
       {label && (
         <Labeling bold ml="8px">
           {label}
+        </Labeling>
+      )}
+      {addtionalText && (
+        <Labeling ml="5px" gray>
+          {addtionalText}
         </Labeling>
       )}
     </Flex>

--- a/src/components/radio/radio-group.tsx
+++ b/src/components/radio/radio-group.tsx
@@ -10,6 +10,7 @@ export interface RadioGroupProps
   extends Omit<RadioProps, 'label' | 'onChange' | 'options' | 'value'> {
   value: string | null;
   options: string[];
+  additionalTexts?: string[];
   onChange: (value: string) => void;
   flexDirection?: 'row' | 'column' | null;
 }
@@ -18,6 +19,7 @@ const RadioGroup: FC<RadioGroupProps> = ({
   options,
   value,
   onChange,
+  additionalTexts,
   flexDirection = 'column',
   ...props
 }: RadioGroupProps) => {
@@ -32,7 +34,7 @@ const RadioGroup: FC<RadioGroupProps> = ({
 
   return (
     <Flex flexDirection={flexDirection}>
-      {options?.map((option) => (
+      {options?.map((option, idx) => (
         <Radio
           {...props}
           key={option}
@@ -40,6 +42,7 @@ const RadioGroup: FC<RadioGroupProps> = ({
           checked={value === option}
           label={option}
           name={name}
+          addtionalText={additionalTexts?.[idx]}
           onChange={handleChange(option)}
         />
       ))}

--- a/src/components/radio/radio.stories.tsx
+++ b/src/components/radio/radio.stories.tsx
@@ -19,6 +19,7 @@ const GroupTemplate: Story<RadioGroupProps> = (props) => {
       onChange={setValue}
       mr="auto"
       options={['nullable', 'required', 'email', 'url']}
+      additionalTexts={['text1', 'text2', 'text3', 'text4']}
     />
   );
 };
@@ -59,6 +60,12 @@ Group.argTypes = {
       required: true,
     },
   },
+  additionalTexts: {
+    type: {
+      summary: 'Array of strings',
+      required: false,
+    },
+  },
   flexDirection: {
     control: {
       type: 'select',
@@ -85,6 +92,12 @@ Default.argTypes = {
   disabled: {
     control: {
       type: 'boolean',
+    },
+  },
+  additionalTexts: {
+    type: {
+      summary: 'Array of strings',
+      required: false,
     },
   },
   label: {


### PR DESCRIPTION
# Hopsworks 2465 Secrets
Related to: [HOPSWORKS-2465](https://logicalclocks.atlassian.net/browse/HOPSWORKS-2465)

### RadioButton
- Add `additionalText` to radio button