### PR TITLE
Trello#425 Fix Table Component

### DIFF
--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -22,7 +22,7 @@ const Dropdown: FC<DropdownProps> = ({
   ...props
 }: DropdownProps) => {
   const containerRef = useRef(null);
-  useOnClickOutside(containerRef, onClickOutside);
+  useOnClickOutside(onClickOutside, [containerRef]);
 
   if (!isOpen) {
     return null;

--- a/src/components/editableSelect/EditableSelectDropdown.tsx
+++ b/src/components/editableSelect/EditableSelectDropdown.tsx
@@ -18,6 +18,7 @@ export interface EditableSelectDropdownProps {
   maxHeight: string;
   type?: EditableSelectTypes;
   isMulti: boolean;
+  appendToBody: boolean;
   onChange: (value: string[]) => void;
   onClose: () => void;
 }
@@ -33,6 +34,7 @@ const EditableSelectDropdown: FC<EditableSelectDropdownProps> = ({
   position,
   onChange,
   maxHeight,
+  appendToBody,
 }) => {
   const handleClick = useCallback(
     (option: string) => () => {
@@ -61,7 +63,7 @@ const EditableSelectDropdown: FC<EditableSelectDropdownProps> = ({
 
   return (
     <List
-      sx={listStyles(position)}
+      sx={listStyles(position, appendToBody)}
       minWidth={width}
       width="max-content"
       maxHeight={maxHeight}

--- a/src/components/editableSelect/editableSelect.stories.tsx
+++ b/src/components/editableSelect/editableSelect.stories.tsx
@@ -56,6 +56,7 @@ Default.args = {
   variant: 'primary',
   intent: 'default',
   isMulti: true,
+  appendToBody: false,
   inlineLegend: '',
 };
 
@@ -107,6 +108,10 @@ Default.argTypes = {
   isMulti: {
     control: { type: 'boolean' },
     type: { required: true },
+  },
+  appendToBody: {
+    control: { type: 'boolean' },
+    type: { required: false },
   },
   type: {
     type: { required: false },

--- a/src/components/editableSelect/editableSelect.styles.ts
+++ b/src/components/editableSelect/editableSelect.styles.ts
@@ -17,9 +17,11 @@ export const chipStyles = {
   cursor: 'default',
 };
 
-const getIntentColor = (intent: Intents) => ({ inputIntents }: ITheme) => {
-  return inputIntents[intent] ?? 'transparent';
-};
+const getIntentColor =
+  (intent: Intents) =>
+  ({ inputIntents }: ITheme) => {
+    return inputIntents[intent] ?? 'transparent';
+  };
 
 export const getContainerStyles = (intent: Intents): SxStyleProp => ({
   position: 'relative',
@@ -67,11 +69,18 @@ export const inputStyles = (): SxStyleProp => {
   };
 };
 
-export const listStyles = (parentHeight: number): SxStyleProp => ({
+export const listStyles = (
+  parentHeight: number,
+  appendToBody: boolean,
+): SxStyleProp => ({
   position: 'absolute',
   zIndex: 'popups',
   left: 0,
   top: `${parentHeight}px`,
+  ...(appendToBody && {
+    marginTop: '2px !important',
+    marginLeft: '1px !important',
+  }),
 });
 
 export const messageStyles = {

--- a/src/components/editableSelect/index.tsx
+++ b/src/components/editableSelect/index.tsx
@@ -1,4 +1,11 @@
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import useDropdown from '../../utils/useDropdown';
 import useOnClickOutside from '../../utils/useClickOutside';
 import { Intents } from '../intents';
@@ -93,14 +100,14 @@ const EditableSelect: FC<EditableSelectProps> = ({
     }
   }, [search]);
 
-  const dropdrownWidth = useMemo(() => {
+  const dropdrownWidth = useCallback(() => {
     if (containerRef.current) {
       return `${containerRef.current.offsetWidth - 2}px`;
     }
     return 'auto';
   }, [containerRef.current?.offsetWidth]);
 
-  const dropdrownPosition = useMemo(() => {
+  const dropdrownPosition = useCallback(() => {
     if (containerRef.current) {
       return containerRef.current.offsetHeight + 1;
     }
@@ -113,7 +120,9 @@ const EditableSelect: FC<EditableSelectProps> = ({
     // eslint-disable-next-line arrow-body-style
   }) => {
     return appendToBody ? (
-      <StickyPortal refEl={refEl}>{children}</StickyPortal>
+      <StickyPortal refEl={refEl} handleClose={handleClickOutside}>
+        {children}
+      </StickyPortal>
     ) : (
       children
     );
@@ -154,11 +163,11 @@ const EditableSelect: FC<EditableSelectProps> = ({
               search={search}
               isMulti={isMulti}
               onClose={handleToggle}
-              width={dropdrownWidth}
+              width={dropdrownWidth()}
               maxHeight={maxListHeight}
               options={filteredOptions}
               appendToBody={appendToBody}
-              position={dropdrownPosition}
+              position={dropdrownPosition()}
               onChange={handleValueChange}
             />
           </DropdownWrapper>

--- a/src/components/editableSelect/index.tsx
+++ b/src/components/editableSelect/index.tsx
@@ -7,9 +7,11 @@ import EditableSelectContainer from './EditableSelectContainer';
 import EditableSelectDropdown from './EditableSelectDropdown';
 import EditableSelectInfo from './EditableSelectInfo';
 import { EditableSelectTypes, ChipsVariants } from './types';
+import StickyPortal from '../sticky-portal/StickyPortal';
 
 export interface EditableSelectProps
   extends Omit<LabelProps, 'onChange' | 'children'> {
+  appendToBody?: boolean;
   info?: string;
   label?: string;
   width?: string;
@@ -39,6 +41,7 @@ const EditableSelect: FC<EditableSelectProps> = ({
   labelAction,
   placeholder,
   inlineLegend,
+  appendToBody = false,
   width = 'auto',
   isMulti = true,
   type = 'editable',
@@ -104,6 +107,18 @@ const EditableSelect: FC<EditableSelectProps> = ({
     return 33;
   }, [containerRef.current?.offsetHeight]);
 
+  const DropdownWrapper: FC<{ children: any; refEl: any }> = ({
+    children,
+    refEl,
+    // eslint-disable-next-line arrow-body-style
+  }) => {
+    return appendToBody ? (
+      <StickyPortal refEl={refEl}>{children}</StickyPortal>
+    ) : (
+      children
+    );
+  };
+
   return (
     <Label
       as="span"
@@ -132,18 +147,21 @@ const EditableSelect: FC<EditableSelectProps> = ({
         variant={disabled ? 'disabled' : (variant as ChipsVariants)}
       >
         {isOpen && (
-          <EditableSelectDropdown
-            type={type}
-            value={value}
-            search={search}
-            isMulti={isMulti}
-            onClose={handleToggle}
-            width={dropdrownWidth}
-            maxHeight={maxListHeight}
-            options={filteredOptions}
-            position={dropdrownPosition}
-            onChange={handleValueChange}
-          />
+          <DropdownWrapper refEl={containerRef?.current || undefined}>
+            <EditableSelectDropdown
+              type={type}
+              value={value}
+              search={search}
+              isMulti={isMulti}
+              onClose={handleToggle}
+              width={dropdrownWidth}
+              maxHeight={maxListHeight}
+              options={filteredOptions}
+              appendToBody={appendToBody}
+              position={dropdrownPosition}
+              onChange={handleValueChange}
+            />
+          </DropdownWrapper>
         )}
       </EditableSelectContainer>
       {info && <EditableSelectInfo intent={intent}>{info}</EditableSelectInfo>}

--- a/src/components/editableSelect/index.tsx
+++ b/src/components/editableSelect/index.tsx
@@ -14,7 +14,7 @@ import EditableSelectContainer from './EditableSelectContainer';
 import EditableSelectDropdown from './EditableSelectDropdown';
 import EditableSelectInfo from './EditableSelectInfo';
 import { EditableSelectTypes, ChipsVariants } from './types';
-import StickyPortal from '../sticky-portal/StickyPortal';
+import StickyPortal, { CONTENT_ID } from '../sticky-portal/StickyPortal';
 
 export interface EditableSelectProps
   extends Omit<LabelProps, 'onChange' | 'children'> {
@@ -63,7 +63,12 @@ const EditableSelect: FC<EditableSelectProps> = ({
   const [search, setSearch] = useState(isMulti ? '' : value[0] || '');
 
   const [isOpen, handleToggle, handleClickOutside] = useDropdown(false);
-  useOnClickOutside<HTMLDivElement>(containerRef, handleClickOutside);
+
+  useOnClickOutside<HTMLDivElement>(
+    handleClickOutside,
+    [containerRef],
+    [CONTENT_ID],
+  );
 
   const unselectedOpts = useMemo(
     () => options.filter((opt) => !value.includes(opt)),

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -21,7 +21,7 @@ import Input from '../input';
 import Value from '../typography/value';
 import useKeyUp from '../../utils/useKeyUp';
 import icons from '../../sources/icons';
-import StickyPortal from '../sticky-portal/StickyPortal';
+import StickyPortal, { CONTENT_ID } from '../sticky-portal/StickyPortal';
 
 export interface SelectProps extends Omit<LabelProps, 'onChange' | 'children'> {
   value: string[];
@@ -87,7 +87,11 @@ const Select: FC<SelectProps> = ({
 }: SelectProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isOpen, handleToggle, handleClickOutside] = useDropdown(false);
-  useOnClickOutside<HTMLDivElement>(containerRef, handleClickOutside);
+  useOnClickOutside<HTMLDivElement>(
+    handleClickOutside,
+    [containerRef],
+    [CONTENT_ID],
+  );
 
   const [search, setSearch] = useState('');
 

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -143,20 +143,22 @@ const Select: FC<SelectProps> = ({
     // eslint-disable-next-line arrow-body-style
   }) => {
     return appendToBody ? (
-      <StickyPortal refEl={refEl}>{children}</StickyPortal>
+      <StickyPortal handleClose={handleClickOutside} refEl={refEl}>
+        {children}
+      </StickyPortal>
     ) : (
       children
     );
   };
 
-  const dropdrownPosition = useMemo(() => {
+  const dropdrownPosition = useCallback(() => {
     if (containerRef?.current) {
       return containerRef.current.offsetHeight + 1;
     }
     return 33;
   }, [containerRef.current?.offsetHeight]);
 
-  const dropdrownWidth = useMemo(() => {
+  const dropdrownWidth = useCallback(() => {
     if (listWidth === '100%' && containerRef.current) {
       return `${containerRef.current.offsetWidth - 2}px`;
     }
@@ -194,8 +196,8 @@ const Select: FC<SelectProps> = ({
         {isOpen && (
           <DropdownWrapper refEl={containerRef?.current || undefined}>
             <List
-              sx={listStyles(dropdrownPosition, appendToBody)}
-              width={dropdrownWidth}
+              sx={listStyles(dropdrownPosition(), appendToBody)}
+              width={dropdrownWidth()}
               maxHeight={maxListHeight}
             >
               <Flex>

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -21,12 +21,14 @@ import Input from '../input';
 import Value from '../typography/value';
 import useKeyUp from '../../utils/useKeyUp';
 import icons from '../../sources/icons';
+import StickyPortal from '../sticky-portal/StickyPortal';
 
 export interface SelectProps extends Omit<LabelProps, 'onChange' | 'children'> {
   value: string[];
   options: string[];
   placeholder: string;
   isMulti?: boolean;
+  appendToBody?: boolean;
   label?: string;
   disabled?: boolean;
   width?: string | number;
@@ -59,7 +61,7 @@ const Select: FC<SelectProps> = ({
   variant = 'primary',
   options,
   disabled,
-  listWidth = 'max-content',
+  listWidth,
   value,
   isMulti,
   placeholder,
@@ -80,9 +82,10 @@ const Select: FC<SelectProps> = ({
   needSecondaryText = true,
   deletabled,
   needSwap = false,
+  appendToBody = false,
   ...props
 }: SelectProps) => {
-  const containerRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [isOpen, handleToggle, handleClickOutside] = useDropdown(false);
   useOnClickOutside<HTMLDivElement>(containerRef, handleClickOutside);
 
@@ -134,6 +137,35 @@ const Select: FC<SelectProps> = ({
     }
   }, [handleToggle, disabled]);
 
+  const DropdownWrapper: FC<{ children: any; refEl: any }> = ({
+    children,
+    refEl,
+    // eslint-disable-next-line arrow-body-style
+  }) => {
+    return appendToBody ? (
+      <StickyPortal refEl={refEl}>{children}</StickyPortal>
+    ) : (
+      children
+    );
+  };
+
+  const dropdrownPosition = useMemo(() => {
+    if (containerRef?.current) {
+      return containerRef.current.offsetHeight + 1;
+    }
+    return 33;
+  }, [containerRef.current?.offsetHeight]);
+
+  const dropdrownWidth = useMemo(() => {
+    if (listWidth === '100%' && containerRef.current) {
+      return `${containerRef.current.offsetWidth - 2}px`;
+    }
+    if (listWidth && listWidth !== '') {
+      return listWidth;
+    }
+    return 'max-content';
+  }, [containerRef.current?.offsetWidth, listWidth]);
+
   return (
     <Label
       action={labelAction}
@@ -160,77 +192,83 @@ const Select: FC<SelectProps> = ({
         needSwap={needSwap}
       >
         {isOpen && (
-          <List sx={listStyles} width={listWidth} maxHeight={maxListHeight}>
-            <Flex>
-              {!!customFilter && customFilter}
-              {hasSearch && (
-                <Flex flex={1} ml="20px">
-                  <Box
-                    mt="20px"
-                    mr="-34px"
-                    sx={{
-                      svg: {
-                        width: '14px',
-                        height: '14px',
+          <DropdownWrapper refEl={containerRef?.current || undefined}>
+            <List
+              sx={listStyles(dropdrownPosition, appendToBody)}
+              width={dropdrownWidth}
+              maxHeight={maxListHeight}
+            >
+              <Flex>
+                {!!customFilter && customFilter}
+                {hasSearch && (
+                  <Flex flex={1} ml="20px">
+                    <Box
+                      mt="20px"
+                      mr="-34px"
+                      sx={{
+                        svg: {
+                          width: '14px',
+                          height: '14px',
 
-                        path: {
-                          fill: 'gray',
+                          path: {
+                            fill: 'gray',
+                          },
                         },
-                      },
-                      zIndex: 1,
-                    }}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    {icons.glass}
-                  </Box>
-                  <Input
-                    pl="32px"
-                    m="10px"
-                    width="100%"
-                    value={search}
-                    placeholder={searchPlaceholder}
-                    onChange={({ target }) => setSearch(target.value)}
-                    onClick={(e) => e.stopPropagation()}
+                        zIndex: 1,
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {icons.glass}
+                    </Box>
+                    <Input
+                      pl="32px"
+                      m="10px"
+                      width="100%"
+                      value={search}
+                      placeholder={searchPlaceholder}
+                      onChange={({ target }) => setSearch(target.value)}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </Flex>
+                )}
+              </Flex>
+              {(!!customFilter || hasSearch) && (
+                <Divider my={0} width="calc(100% + 20px)" />
+              )}
+              {!!filteredOptions.length ? (
+                isMulti ? (
+                  // Multi choice
+                  <SelectListMulti
+                    value={value}
+                    onChange={onChange}
+                    onClose={handleToggle}
+                    options={filteredOptions}
+                    additionalTexts={filteredAdditionalTexts}
+                    additionalComponents={filteredAdditionalComponents}
                   />
+                ) : (
+                  // Single choice
+                  <SelectList
+                    value={value}
+                    onChange={onChange}
+                    onClose={handleToggle}
+                    options={filteredOptions}
+                    additionalTexts={filteredAdditionalTexts}
+                    additionalComponents={filteredAdditionalComponents}
+                  />
+                )
+              ) : (
+                <Flex height="55px" alignItems="center" justifyContent="center">
+                  <Value>{noMathText}</Value>
                 </Flex>
               )}
-            </Flex>
-            {(!!customFilter || hasSearch) && (
-              <Divider my={0} width="calc(100% + 20px)" />
-            )}
-            {!!filteredOptions.length ? (
-              isMulti ? (
-                // Multi choice
-                <SelectListMulti
-                  value={value}
-                  onChange={onChange}
-                  onClose={handleToggle}
-                  options={filteredOptions}
-                  additionalTexts={filteredAdditionalTexts}
-                  additionalComponents={filteredAdditionalComponents}
-                />
-              ) : (
-                // Single choice
-                <SelectList
-                  value={value}
-                  onChange={onChange}
-                  onClose={handleToggle}
-                  options={filteredOptions}
-                  additionalTexts={filteredAdditionalTexts}
-                  additionalComponents={filteredAdditionalComponents}
-                />
-              )
-            ) : (
-              <Flex height="55px" alignItems="center" justifyContent="center">
-                <Value>{noMathText}</Value>
-              </Flex>
-            )}
-            {bottomActionText && (
-              <Box sx={bottomActionStyles} onClick={bottomActionHandler}>
-                {bottomActionText}
-              </Box>
-            )}
-          </List>
+              {bottomActionText && (
+                <Box sx={bottomActionStyles} onClick={bottomActionHandler}>
+                  {bottomActionText}
+                </Box>
+              )}
+            </List>
+          </DropdownWrapper>
         )}
       </SelectLabel>
       {info && <SelectInfo intent={intent}>{info}</SelectInfo>}

--- a/src/components/select/select.stories.tsx
+++ b/src/components/select/select.stories.tsx
@@ -69,6 +69,7 @@ Default.args = {
   listWidth: '100%',
   variant: 'primary',
   hasPlaceholder: false,
+  appendToBody: false,
   isMulti: false,
   noDataMessage: 'no labels',
   hasSearch: true,
@@ -163,6 +164,10 @@ Default.argTypes = {
     },
   },
   disabled: {
+    type: { required: false },
+    control: { type: 'boolean' },
+  },
+  appendToBody: {
     type: { required: false },
     control: { type: 'boolean' },
   },

--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -1,15 +1,25 @@
+import { SxStyleProp } from 'rebass';
 import { ITheme } from '../../theme/types';
 import { Intents } from '../intents';
 
-const getIntentColor = (intent: Intents) => ({ inputIntents }: ITheme) =>
-  inputIntents[intent] ?? 'transparent';
+const getIntentColor =
+  (intent: Intents) =>
+  ({ inputIntents }: ITheme) =>
+    inputIntents[intent] ?? 'transparent';
 
-export const listStyles = {
+export const listStyles = (
+  parentHeight: number,
+  appendToBody: boolean,
+): SxStyleProp => ({
   position: 'absolute',
   zIndex: 'popups',
   left: 0,
-  top: '33px',
-};
+  top: `${parentHeight}px`,
+  ...(appendToBody && {
+    marginTop: '2px !important',
+    marginLeft: '1px !important',
+  }),
+});
 
 export const bottomActionStyles = {
   p: '10px',

--- a/src/components/sticky-portal/StickyPortal.tsx
+++ b/src/components/sticky-portal/StickyPortal.tsx
@@ -1,0 +1,32 @@
+import { createPortal } from 'react-dom';
+import { FC, useEffect, useRef } from 'react';
+
+export interface StickyPortalProps {
+  children: any;
+  refEl?: HTMLDivElement;
+}
+
+const StickyPortal: FC<StickyPortalProps> = ({ children, refEl }) => {
+  const rootElemRef = useRef(document.createElement('div'));
+
+  useEffect(() => {
+    document.body.appendChild(rootElemRef.current);
+
+    const refElPos = refEl?.getBoundingClientRect();
+    const content = rootElemRef.current.children[0] as HTMLElement;
+
+    if (refElPos) {
+      content.style.top = `${refElPos.top + refElPos.height}px`;
+      content.style.left = `${refElPos.left}px`;
+    }
+    return () => {
+      if (rootElemRef.current) {
+        document.body.removeChild(rootElemRef.current);
+      }
+    };
+  }, [refEl]);
+
+  return createPortal(children, rootElemRef.current);
+};
+
+export default StickyPortal;

--- a/src/components/sticky-portal/StickyPortal.tsx
+++ b/src/components/sticky-portal/StickyPortal.tsx
@@ -7,7 +7,7 @@ export interface StickyPortalProps {
   refEl?: HTMLDivElement;
 }
 
-const CONTENT_ID = 'portal-content';
+export const CONTENT_ID = 'portal-content';
 
 const StickyPortal: FC<StickyPortalProps> = ({
   children,

--- a/src/components/sticky-portal/StickyPortal.tsx
+++ b/src/components/sticky-portal/StickyPortal.tsx
@@ -47,8 +47,8 @@ const StickyPortal: FC<StickyPortalProps> = ({
     window.addEventListener('scroll', listenerAction, true);
     window.addEventListener('resize', listenerAction, true);
     return () => {
-      document.body.removeEventListener('scroll', listenerAction);
-      document.body.removeEventListener('resize', listenerAction);
+      window.removeEventListener('scroll', listenerAction);
+      window.removeEventListener('resize', listenerAction);
     };
   }, []);
 

--- a/src/components/sticky-portal/StickyPortal.tsx
+++ b/src/components/sticky-portal/StickyPortal.tsx
@@ -47,8 +47,8 @@ const StickyPortal: FC<StickyPortalProps> = ({
     window.addEventListener('scroll', listenerAction, true);
     window.addEventListener('resize', listenerAction, true);
     return () => {
-      window.removeEventListener('scroll', listenerAction);
-      window.removeEventListener('resize', listenerAction);
+      window.removeEventListener('scroll', listenerAction, true);
+      window.removeEventListener('resize', listenerAction, true);
     };
   }, []);
 

--- a/src/components/table/editable/row-left-content.tsx
+++ b/src/components/table/editable/row-left-content.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback, useState } from 'react';
+import React, { FC, memo, useCallback } from 'react';
 import { Box } from 'rebass';
 import { IconButton } from '../../../index';
 import { IconName } from '../../icon/list';

--- a/src/components/table/editable/row-left-content.tsx
+++ b/src/components/table/editable/row-left-content.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useCallback } from 'react';
+import React, { FC, memo, useCallback, useState } from 'react';
 import { Box } from 'rebass';
 import { IconButton } from '../../../index';
 import { IconName } from '../../icon/list';
@@ -14,10 +14,14 @@ const styles = {
   boxSizing: 'content-box',
   '> div': {
     display: 'none',
+    height: '15px',
+    marginTop: '-9px',
     '> button': {
-      width: '31px',
-      height: 'auto',
-      padding: '9px 12px 9px 15px',
+      width: '30px',
+      height: '32px',
+      paddingTop: '16px',
+      paddingRight: '13px',
+      paddingLeft: '14px',
       maxHeight: '35px',
     },
     svg: {
@@ -39,12 +43,13 @@ const RowLeftContent: FC<RowLeftContentProps> = ({
       py="9px !important"
       id={String(index + 1)}
       sx={styles}
+      height="14px"
       onClick={handleDeleteRow}
     >
       <span>{index + 1}</span>
       <IconButton
         py="9px !import"
-        px="12px !important"
+        pt="12px !important"
         pr="20px"
         tooltipProps={{ position: TooltipPositions.right }}
         tooltip="remove"

--- a/src/components/table/read-only/index.tsx
+++ b/src/components/table/read-only/index.tsx
@@ -45,7 +45,7 @@ export const Thead: FC<TheadProps> = ({
 }: TheadProps) => {
   const containerRef = useRef(null);
   const [isOpen, handleToggle, handleClickOutside] = useDropdown();
-  useOnClickOutside<HTMLDivElement>(containerRef, handleClickOutside);
+  useOnClickOutside<HTMLDivElement>(handleClickOutside, [containerRef]);
 
   const handleToggleList = useCallback(() => {
     handleToggle();

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -147,9 +147,10 @@ export const Editable: Story<ReadOnlyTableProps> = ({ values }) => {
       name: 'home_team_id',
       render: ({ value, onChange }) => (
         <Select
+          appendToBody
           value={value}
           onChange={onChange}
-          options={['1', '2']}
+          options={['1', '2', '3', '4', '5', '6']}
           placeholder=""
         />
       ),
@@ -159,20 +160,22 @@ export const Editable: Story<ReadOnlyTableProps> = ({ values }) => {
   return (
     <>
       <Button onClick={handleAddRow}>Add</Button>
-      <EditableTable
-        columns={columns}
-        values={data}
-        onChangeData={handleChangeData}
-        onDeleteRow={handleRemoveRow}
-        actions={[
-          {
-            label: 'go to stats',
-            handler: (column) => {
-              console.log('go to stats of ' + column);
+      <Box width="500px">
+        <EditableTable
+          columns={columns}
+          values={data}
+          onChangeData={handleChangeData}
+          onDeleteRow={handleRemoveRow}
+          actions={[
+            {
+              label: 'go to stats',
+              handler: (column) => {
+                console.log('go to stats of ' + column);
+              },
             },
-          },
-        ]}
-      />
+          ]}
+        />
+      </Box>
     </>
   );
 };

--- a/src/components/table/table.styles.tsx
+++ b/src/components/table/table.styles.tsx
@@ -110,12 +110,12 @@ export const trowStyles = {
       backgroundColor: 'grayShade2',
     },
     'th[id]': {
-      padding: '0 !important',
       span: {
         display: 'none',
       },
       div: {
-        display: 'inline-block',
+        display: 'block',
+        height: '100%',
       },
     },
   },

--- a/src/utils/useClickOutside.ts
+++ b/src/utils/useClickOutside.ts
@@ -1,16 +1,29 @@
 import { RefObject, useEffect } from 'react';
 
+/**
+ * Triggers the handler on on-click on any element diferent from those defined
+ * either inside the refs or the ids arrays.
+ */
 const useOnClickOutside = <T extends HTMLElement>(
-  ref: RefObject<T>,
   handler: () => void,
+  refs: RefObject<T>[],
+  ids?: string[],
 ) => {
   useEffect(() => {
     const listener = (event: Event) => {
-      // @ts-ignore
-      if (!ref?.current || ref?.current.contains(event.target)) {
+      // Do nothing if click happens on an  element contained in the ids array.
+      if (
+        (ids || []).some((id) => {
+          const el = document.getElementById(id);
+          return el?.contains(event.target as Node);
+        })
+      ) {
         return;
       }
-
+      // Do nothing if click happens on an  element contained in the refs array.
+      if (refs.some((r) => r?.current?.contains(event.target as Node))) {
+        return;
+      }
       handler();
     };
 
@@ -21,7 +34,7 @@ const useOnClickOutside = <T extends HTMLElement>(
       document.removeEventListener('mousedown', listener);
       document.removeEventListener('touchstart', listener);
     };
-  }, [ref, handler]);
+  }, [refs, ids, handler]);
 };
 
 export default useOnClickOutside;


### PR DESCRIPTION
## Fix `Table` & `Select` & `Editable Select` Component
### Fixes: [Trello 425- Fix table](https://trello.com/c/7CObo4k1)

- Fixes Trash icon positioning in `Table Component`.
- Adds new prop to `Select` & `Editable Select` to allow rendering the dropdown as a portal directly into the body.
- Adapt the `useOnClickOutside` hook to receive multiple elements to ignore. 
- Update Storybook for `Table` & `Select` & `Editable Select`
