### PR TITLE
Show error when missing deps in react memo hooks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,9 @@
     "airbnb-typescript",
     "plugin:@typescript-eslint/eslint-recommended"
   ],
+  "plugins": [
+    "react-hooks"
+  ],
   "env": {
     "node": true
   },
@@ -27,6 +30,7 @@
     }
   },
   "rules": {
+    "react-hooks/exhaustive-deps": "error",
     "space-before-function-paren": 0,
     "react/prop-types": 0,
     "react/jsx-handler-names": 0,


### PR DESCRIPTION

Forgetting about passing the required dependencies to react memorization hooks is a recurrent problem, and bugs associated with this are very difficult to spot.

This PR adds the `exhaustive-deps` rule to linter so that an error is shown when there are missing dependencies. 
Only the error is displayed, it doesn't break the compilation. 
