### PR TITLE
Feature/cu 1j4h1pr list all expectations

### DIFF
--- a/src/components/alternative-header/alternative-header.stories.tsx
+++ b/src/components/alternative-header/alternative-header.stories.tsx
@@ -60,7 +60,7 @@ const Template: Story<AlternativeHeaderProps> = (props) => {
         onCLick: () => setActive('last tab'),
       },
     ],
-    [active, setActive],
+    [isActive],
   );
 
   return (
@@ -142,6 +142,15 @@ Default.argTypes = {
 
     type: {
       summary: 'Card width (string or number px, %)',
+    },
+  },
+  withBase: {
+    control: {
+      type: 'boolean',
+    },
+
+    type: {
+      summary: 'Adds a line under the menu',
     },
   },
 };

--- a/src/components/alternative-header/index.tsx
+++ b/src/components/alternative-header/index.tsx
@@ -24,7 +24,7 @@ export interface AlternativeHeaderProps extends Omit<BoxProps, 'css'> {
   rightTopContent?: React.ReactElement;
   rightBottomContent?: React.ReactElement;
   tabs: Tab[];
-  withBase: boolean;
+  withBase?: boolean;
 }
 
 const AlternativeHeader: FC<AlternativeHeaderProps> = ({

--- a/src/components/alternative-header/index.tsx
+++ b/src/components/alternative-header/index.tsx
@@ -24,6 +24,7 @@ export interface AlternativeHeaderProps extends Omit<BoxProps, 'css'> {
   rightTopContent?: React.ReactElement;
   rightBottomContent?: React.ReactElement;
   tabs: Tab[];
+  withBase: boolean;
 }
 
 const AlternativeHeader: FC<AlternativeHeaderProps> = ({
@@ -31,6 +32,7 @@ const AlternativeHeader: FC<AlternativeHeaderProps> = ({
   rightTopContent,
   title,
   tabs,
+  withBase,
   ...props
 }: AlternativeHeaderProps) => {
   const tabRefs = useRef<HTMLDivElement[]>([]);
@@ -77,6 +79,18 @@ const AlternativeHeader: FC<AlternativeHeaderProps> = ({
         width="100%"
         sx={{ position: 'relative' }}
       >
+        {withBase && (
+          <Flex
+            sx={{
+              position: 'absolute',
+              height: '1px',
+              backgroundColor: 'grayShade2',
+              width: '100%',
+              bottom: '0px',
+              zIndex: -1,
+            }}
+          />
+        )}
         <Flex>
           {tabs.map((tab, index) => (
             <Box


### PR DESCRIPTION
### Add prop `withBase` to enable a baseline  in the `Alternative Header`
<img width="965" alt="Screen Shot 2021-11-26 at 11 02 53" src="https://user-images.githubusercontent.com/16487828/143554980-4be32a27-5341-4e69-beef-15976ae2f957.png">
 