### PR TITLE
Data preview always load the data of latest version instead of loading the one of the currently open version

### DIFF
--- a/src/components/navigation/item/index.tsx
+++ b/src/components/navigation/item/index.tsx
@@ -74,7 +74,7 @@ const NavigationItem: FC<NavigationItemProps> = (
   const handleClick = useCallback(() => {
     onClick();
     onActivate(key);
-  }, [disabled]);
+  }, [key, onActivate, onClick]);
 
   useEffect(() => {
     if (isActive) {


### PR DESCRIPTION
Clickup Card: https://app.clickup.com/t/1jvet7r
The card is solved by fixing the bug that in the NavigationItem component, the callback onClick() does not re-render when it is updated