### PR TITLE
improve constants handling

### DIFF
--- a/src/components/datepicker/datepicker.stories.tsx
+++ b/src/components/datepicker/datepicker.stories.tsx
@@ -4,6 +4,8 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 // Components
 import DatePicker, { DatePickerProps } from './index';
 
+import { DATE_TIME } from '../../constants';
+
 export default {
   title: 'Quartz/DatePicker',
   component: DatePicker,
@@ -32,7 +34,7 @@ export const Default = Template.bind({});
 
 Default.args = {
   showTimeSelect: true,
-  dateFormat: 'MMMM d, yyyy h:mm aa',
+  dateFormat: DATE_TIME.DATE_TIME_FULL_MONTH,
   excludeTimes: [new Date()],
 };
 

--- a/src/constants/dateTimeFormats.ts
+++ b/src/constants/dateTimeFormats.ts
@@ -1,0 +1,6 @@
+export const DATE = 'yyyy-MM-dd';
+
+export const DATE_TIME_FULL = 'yyyy-MM-dd HH:mm:ss';
+export const DATE_TIME_SHORT = 'MM.dd.y HH:mm';
+export const DATE_TIME_MILLIS = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+export const DATE_TIME_FULL_MONTH = 'MMMM d, yyyy h:mm aa';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * as DATE_TIME from './dateTimeFormats';

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ import useNavigation from './components/navigation/useNavigation';
 import useOnClickOutside from './utils/useClickOutside';
 
 // constants
-import dateFormat from './utils/dateFormat';
+import * as constants from './constants';
 
 library.add(fas, far);
 
@@ -233,7 +233,7 @@ export {
   graphColors,
   theme,
   // Constants
-  dateFormat,
+  constants,
 };
 
 export type ITheme = import('./theme/types').ITheme;

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,1 +1,0 @@
-export default 'yyyy-MM-dd HH:mm:ss';


### PR DESCRIPTION
This is a suggestion to improve the constants stored in Quartz.

At this point, there is only one `src/utils/dateFormat.ts`, but checking the frontend project I can see there are multiple places where there are repeated date formats that could be stored here. 

The proposed solution makes it easy to see the available constants through the autocomplete feature in the IDEs. 
There is an example of usage in `src/components/datepicker/datepicker.stories.tsx`

**For this PR to be merged, some changes in the frontend are required**