### PR TITLE
fix: label actions not shown when not given

### DIFF
--- a/src/components/select2/index.tsx
+++ b/src/components/select2/index.tsx
@@ -173,6 +173,10 @@ const Select: FC<SelectProps> = ({
   }, [format]);
 
   const labelActions = useMemo(() => {
+    if (!labelAction) {
+      return null;
+    }
+
     if (info && info !== '') {
       return (
         <Flex


### PR DESCRIPTION
This PR removes the `labelActions` if there are no label actions. 
The previous implementation would wrongly render empty spans there.

It does not break anything, as there are no usages of `Select2` with `labelmode='inline'` in the project yet
And this make this render correctly

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/19791699/146340209-606b7ceb-aa09-48be-b9d4-0d6549360915.png) | ![image](https://user-images.githubusercontent.com/19791699/146339979-583a6411-aa7e-4a25-af65-f0bfcd619939.png) |
