### PR TITLE
feat: holy table

### DIFF
--- a/src/components/holy-table/cell/cell.tsx
+++ b/src/components/holy-table/cell/cell.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useContext } from 'react';
 import { Box, BoxProps } from 'rebass';
-import styles from './styles';
 import HolyTableContext from '../holy-table.context';
+import styles from './styles';
 
 interface Props extends Omit<BoxProps, 'css'> {
   children: ReactNode;
@@ -14,10 +14,12 @@ const Cell = ({ sx, children, ...props }: Props) => {
     ...sx,
     ...styles(padded),
   };
+
   return (
     <Box as="td" sx={style} {...props}>
       {children}
     </Box>
   );
 };
+
 export default Cell;

--- a/src/components/holy-table/cell/cell.tsx
+++ b/src/components/holy-table/cell/cell.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode, useContext } from 'react';
+import { Box, BoxProps } from 'rebass';
+import styles from './styles';
+import HolyTableContext from '../holy-table.context';
+
+interface Props extends Omit<BoxProps, 'css'> {
+  children: ReactNode;
+}
+
+const Cell = ({ sx, children, ...props }: Props) => {
+  const { padded } = useContext(HolyTableContext);
+
+  const style = {
+    ...sx,
+    ...styles(padded),
+  };
+  return (
+    <Box as="td" sx={style} {...props}>
+      {children}
+    </Box>
+  );
+};
+export default Cell;

--- a/src/components/holy-table/cell/index.ts
+++ b/src/components/holy-table/cell/index.ts
@@ -1,0 +1,1 @@
+export { default } from './cell';

--- a/src/components/holy-table/cell/styles.ts
+++ b/src/components/holy-table/cell/styles.ts
@@ -1,0 +1,9 @@
+export default function (paddedVertically: boolean) {
+  return {
+    py: paddedVertically ? '12px' : 'initial',
+    whiteSpace: 'pre',
+    px: '20px',
+    ':first-of-type': { pl: '8px' },
+    ':last-of-type': { pr: '8px' },
+  };
+}

--- a/src/components/holy-table/head-cell/head-cell.tsx
+++ b/src/components/holy-table/head-cell/head-cell.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode, useContext } from 'react';
 import { BoxProps } from 'rebass';
 import Labeling from '../../typography/labeling';
-import styles from './styles';
 import HolyTableContext from '../holy-table.context';
+import styles from './styles';
 
 interface Props extends Omit<BoxProps, 'css'> {
   index: number;
@@ -11,17 +11,13 @@ interface Props extends Omit<BoxProps, 'css'> {
 
 const HeadCell = ({ sx, index, children, ...props }: Props) => {
   const { middleColumn } = useContext(HolyTableContext);
+  const shouldCellFillSpace = index === middleColumn;
 
   return (
-    <Labeling
-      sx={styles(index === middleColumn)}
-      gray
-      pb="4px"
-      as="th"
-      {...props}
-    >
+    <Labeling as="th" gray pb="4px" sx={styles(shouldCellFillSpace)} {...props}>
       {children}
     </Labeling>
   );
 };
+
 export default HeadCell;

--- a/src/components/holy-table/head-cell/head-cell.tsx
+++ b/src/components/holy-table/head-cell/head-cell.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode, useContext } from 'react';
+import { BoxProps } from 'rebass';
+import Labeling from '../../typography/labeling';
+import styles from './styles';
+import HolyTableContext from '../holy-table.context';
+
+interface Props extends Omit<BoxProps, 'css'> {
+  index: number;
+  children: ReactNode;
+}
+
+const HeadCell = ({ sx, index, children, ...props }: Props) => {
+  const { middleColumn } = useContext(HolyTableContext);
+
+  return (
+    <Labeling
+      sx={styles(index === middleColumn)}
+      gray
+      pb="4px"
+      as="th"
+      {...props}
+    >
+      {children}
+    </Labeling>
+  );
+};
+export default HeadCell;

--- a/src/components/holy-table/head-cell/index.ts
+++ b/src/components/holy-table/head-cell/index.ts
@@ -1,0 +1,1 @@
+export { default } from './head-cell';

--- a/src/components/holy-table/head-cell/styles.ts
+++ b/src/components/holy-table/head-cell/styles.ts
@@ -1,0 +1,11 @@
+export default function (fillSpace: boolean) {
+  return {
+    textAlign: 'left',
+    width: fillSpace ? '100%' : 'auto',
+    whiteSpace: 'pre',
+    py: '12px',
+    px: '20px',
+    ':first-of-type': { pl: '8px' },
+    ':last-of-type': { pr: '8px' },
+  };
+}

--- a/src/components/holy-table/holy-table.context.ts
+++ b/src/components/holy-table/holy-table.context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+type ContextProps = {
+  bordered: boolean;
+  padded: boolean;
+  hoverable: boolean;
+  middleColumn?: number;
+};
+
+const HolyTableContext = createContext<ContextProps>({
+  bordered: true,
+  padded: true,
+  hoverable: true,
+});
+
+export default HolyTableContext;

--- a/src/components/holy-table/holy-table.stories.tsx
+++ b/src/components/holy-table/holy-table.stories.tsx
@@ -1,0 +1,69 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+import React from 'react';
+import { Box } from 'rebass';
+import HolyTable from '.';
+import { Props } from './holy-table';
+
+export default {
+  title: 'Quartz/HolyTable',
+  component: HolyTable,
+} as Meta;
+
+export const HolyTableExample: Story = (props: Omit<Props, 'children'>) => (
+  <Box>
+    <HolyTable {...props} legend={['name', 'hex', 'rgb']}>
+      <HolyTable.Row>
+        <HolyTable.Cell>Black</HolyTable.Cell>
+        <HolyTable.Cell>#000000</HolyTable.Cell>
+        <HolyTable.Cell>0, 0, 0</HolyTable.Cell>
+      </HolyTable.Row>
+      <HolyTable.Row>
+        <HolyTable.Cell>White</HolyTable.Cell>
+        <HolyTable.Cell>#ffffff</HolyTable.Cell>
+        <HolyTable.Cell>255, 255, 255</HolyTable.Cell>
+      </HolyTable.Row>
+    </HolyTable>
+  </Box>
+);
+
+HolyTableExample.args = {
+  padded: true,
+  bordered: true,
+  hoverable: true,
+};
+
+HolyTableExample.argTypes = {
+  padded: {
+    control: {
+      type: 'boolean',
+    },
+    type: {
+      required: false,
+    },
+  },
+  bordered: {
+    control: {
+      type: 'boolean',
+    },
+    type: {
+      required: false,
+    },
+  },
+  hoverable: {
+    control: {
+      type: 'boolean',
+    },
+    type: {
+      required: false,
+    },
+  },
+  middleColumn: {
+    control: {
+      type: 'select',
+      options: [0, 1, 2],
+    },
+    type: {
+      required: false,
+    },
+  },
+};

--- a/src/components/holy-table/holy-table.stories.tsx
+++ b/src/components/holy-table/holy-table.stories.tsx
@@ -10,7 +10,7 @@ export default {
 } as Meta;
 
 export const HolyTableExample: Story = (props: Omit<Props, 'children'>) => (
-  <Box>
+  <Box width="700px">
     <HolyTable {...props} legend={['name', 'hex', 'rgb']}>
       <HolyTable.Row>
         <HolyTable.Cell>Black</HolyTable.Cell>

--- a/src/components/holy-table/holy-table.tsx
+++ b/src/components/holy-table/holy-table.tsx
@@ -1,0 +1,47 @@
+import React, { FC, ReactNode } from 'react';
+import { Box } from 'rebass';
+import HeadCell from './head-cell/head-cell';
+import HolyTableContext from './holy-table.context';
+import styles from './styles';
+
+export interface Props {
+  legend?: string[];
+  children: ReactNode;
+  bordered?: boolean;
+  padded?: boolean;
+  hoverable?: boolean;
+  middleColumn?: number;
+}
+
+const HolyTable: FC<Props> = ({
+  legend,
+  children,
+  middleColumn,
+  bordered = true,
+  padded = true,
+  hoverable = true,
+  ...props
+}) => (
+  <HolyTableContext.Provider
+    value={{ bordered, padded, hoverable, middleColumn }}
+  >
+    <Box as="table" sx={styles} {...props}>
+      <Box as="thead">
+        {!!legend && (
+          <Box as="tr" width="100%">
+            {legend.map((name, index) => (
+              // there was no other way for generating keys :()
+              // eslint-disable-next-line react/no-array-index-key
+              <HeadCell key={name + index} index={index}>
+                {name}
+              </HeadCell>
+            ))}
+          </Box>
+        )}
+      </Box>
+      <Box as="tbody">{children}</Box>
+    </Box>
+  </HolyTableContext.Provider>
+);
+
+export default HolyTable;

--- a/src/components/holy-table/holy-table.tsx
+++ b/src/components/holy-table/holy-table.tsx
@@ -27,7 +27,7 @@ const HolyTable: FC<Props> = ({
   >
     <Box as="table" sx={styles} {...props}>
       <Box as="thead">
-        {!!legend && (
+        {legend && (
           <Box as="tr" width="100%">
             {legend.map((name, index) => (
               // there was no other way for generating keys :()

--- a/src/components/holy-table/index.tsx
+++ b/src/components/holy-table/index.tsx
@@ -1,0 +1,16 @@
+import Cell from './cell/cell';
+import Row from './row';
+import HolyTable from './holy-table';
+
+type HolyTable = typeof HolyTable;
+
+interface HolyTableComponent extends HolyTable {
+  Cell: typeof Cell;
+  Row: typeof Row;
+}
+
+(HolyTable as HolyTableComponent).Cell = Cell;
+(HolyTable as HolyTableComponent).Row = Row;
+
+export type { Props as HolyTableProps } from './holy-table';
+export default HolyTable as HolyTableComponent;

--- a/src/components/holy-table/index.tsx
+++ b/src/components/holy-table/index.tsx
@@ -2,9 +2,9 @@ import Cell from './cell/cell';
 import Row from './row';
 import HolyTable from './holy-table';
 
-type HolyTable = typeof HolyTable;
+type IHolyTable = typeof HolyTable;
 
-interface HolyTableComponent extends HolyTable {
+interface HolyTableComponent extends IHolyTable {
   Cell: typeof Cell;
   Row: typeof Row;
 }

--- a/src/components/holy-table/row/index.ts
+++ b/src/components/holy-table/row/index.ts
@@ -1,0 +1,1 @@
+export { default } from './row';

--- a/src/components/holy-table/row/row.tsx
+++ b/src/components/holy-table/row/row.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactNode, useContext } from 'react';
 import { Box, BoxProps } from 'rebass';
-import styles from './styles';
 import HolyTableContext from '../holy-table.context';
+import styles from './styles';
 
 interface Props extends Omit<BoxProps, 'css'> {
   children: ReactNode;
@@ -14,10 +14,12 @@ const Row: FC<Props> = ({ sx, children, ...props }: Props) => {
     ...styles(bordered, hoverable),
     ...sx,
   };
+
   return (
     <Box as="tr" sx={style} width="100%" {...props}>
       {children}
     </Box>
   );
 };
+
 export default Row;

--- a/src/components/holy-table/row/row.tsx
+++ b/src/components/holy-table/row/row.tsx
@@ -1,0 +1,23 @@
+import React, { FC, ReactNode, useContext } from 'react';
+import { Box, BoxProps } from 'rebass';
+import styles from './styles';
+import HolyTableContext from '../holy-table.context';
+
+interface Props extends Omit<BoxProps, 'css'> {
+  children: ReactNode;
+}
+
+const Row: FC<Props> = ({ sx, children, ...props }: Props) => {
+  const { bordered, hoverable } = useContext(HolyTableContext);
+
+  const style = {
+    ...styles(bordered, hoverable),
+    ...sx,
+  };
+  return (
+    <Box as="tr" sx={style} width="100%" {...props}>
+      {children}
+    </Box>
+  );
+};
+export default Row;

--- a/src/components/holy-table/row/styles.ts
+++ b/src/components/holy-table/row/styles.ts
@@ -1,0 +1,31 @@
+enum BorderSides {
+  left = 'Left',
+  right = 'Right',
+  top = 'Top',
+  bottom = 'Bottom',
+}
+
+function createBorder(side: BorderSides): { [key: string]: string } {
+  return {
+    [`border${side}Style`]: 'solid',
+    [`border${side}Width`]: '1px',
+    [`border${side}Color`]: 'grayShade2',
+  };
+}
+
+const borders = {
+  ...createBorder(BorderSides.top),
+  ...createBorder(BorderSides.bottom),
+};
+
+const hover = {
+  ':hover': {
+    bg: 'grayShade3',
+  },
+};
+
+export default (bordered: boolean, hoverable: boolean) => ({
+  bg: 'white',
+  ...(bordered ? borders : {}),
+  ...(hoverable ? hover : {}),
+});

--- a/src/components/holy-table/styles.ts
+++ b/src/components/holy-table/styles.ts
@@ -1,0 +1,5 @@
+export default {
+  tableLayout: 'auto',
+  borderCollapse: 'collapse',
+  width: '100%',
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ import MultiRangeSlider from './components/picker/multi-range-slider';
 
 // Table
 import Table from './components/table';
+import HolyTable from './components/holy-table';
 import ReadOnlyTable from './components/table/read-only';
 import EditableTable from './components/table/editable';
 import BlurInput from './components/table/editable/blur-input';
@@ -213,6 +214,7 @@ export {
   Table,
   EditableTable,
   ReadOnlyTable,
+  HolyTable,
   //  Typography
   Value,
   Text,
@@ -242,6 +244,7 @@ export type BadgeProps = import('./components/badges').BadgeProps;
 export type CardProps = import('./components/card').CardProps;
 export type IThemeColors = import('./theme/types').IThemeColors;
 export type TableCell = import('./components/table/type').TableCell;
+export type HolyTableProps = import('./components/holy-table').HolyTableProps;
 export type TableHeader = import('./components/table/type').TableHeader;
 export type ColumnIdentifier =
   import('./components/table/type').ColumnIdentifier;


### PR DESCRIPTION
Hey, I made a new table. It's called HolyTable, as in the designs:
![image](https://user-images.githubusercontent.com/19791699/147574773-082ca9ed-075d-4bca-b31d-b432e439772a.png)

It's basically a much simpler re-write of the old thing called `Row`, which was atrocious to use.
The API is very simple

```jsx

	<HolyTable legend={['name', 'hex', 'rgb']}>
      <HolyTable.Row>
        <HolyTable.Cell>Black</HolyTable.Cell>
        <HolyTable.Cell>#000000</HolyTable.Cell>
        <HolyTable.Cell>0, 0, 0</HolyTable.Cell>
      </HolyTable.Row>
      <HolyTable.Row>
        <HolyTable.Cell>White</HolyTable.Cell>
        <HolyTable.Cell>#ffffff</HolyTable.Cell>
        <HolyTable.Cell>255, 255, 255</HolyTable.Cell>
      </HolyTable.Row>
    </HolyTable>
```

And you get a 
![image](https://user-images.githubusercontent.com/19791699/147574885-bb883fc8-28d6-45f0-b0f0-3e3930e2f075.png)


There are boolean props: 
- **hoverable**: whether we have this hover effect
- **bordered**: whether it has borders
- **padded**: whether it has paddings inside the data, as we have cases where the data needs to be dense

This also ports the beloved `middleColumn` prop too.
Otherwise I've tried to make it very very simple as opposed to what we previously had.

### DEMO:

https://user-images.githubusercontent.com/19791699/147575208-08f238a3-b5d5-456b-b079-b59ecbb7fcd6.mp4

Let's just forget things like
``` typescript
groupComponents={[
      [
        () => {},
        function noRefCheck() {},
        function noRefCheck() {},
        function noRefCheck() {},
        function noRefCheck() {}
      ],
      [
        function noRefCheck() {},
        function noRefCheck() {},
        function noRefCheck() {},
        function noRefCheck() {},
        function noRefCheck() {}
      ]
    ]}
    groupProps={[
      [
        {
          name: 'Name'
        },
        {
          children: 'Button',
          onClick: function noRefCheck() {},
          width: '100%'
        },
        {
          children: 'Text1',
          color: 'black'
        },
        {
          children: 'Text2',
          color: 'black'
        },
        {
          children: 'Text3',
          color: 'black'
        }
      ],
      [
        {
          name: 'Name'
        },
        {
          children: 'Button 2',
          onClick: function noRefCheck() {}
        },
        {
          children: 'Text4',
          color: 'black'
        },
        {
          children: 'Text5',
          color: 'black'
        },
        {
          children: 'Text6',
          color: 'black'
        }
      ]