### PR TITLE
style: spacing for radio

### DIFF
--- a/src/components/radio/radio-group.tsx
+++ b/src/components/radio/radio-group.tsx
@@ -28,10 +28,10 @@ const RadioGroup: FC<RadioGroupProps> = ({
   ...props
 }: RadioGroupProps) => {
   const handleChange = useCallback(
-    (value: string) => () => {
-      onChange(value);
+    (newValue: string) => () => {
+      onChange(newValue);
     },
-    [value, onChange],
+    [onChange],
   );
 
   const name = randomString();
@@ -42,7 +42,8 @@ const RadioGroup: FC<RadioGroupProps> = ({
         <Radio
           {...props}
           key={option}
-          mt={flexDirection === 'column' ? 2 : 0}
+          mt={flexDirection === 'column' ? 2 : 'initial'}
+          mr={flexDirection === 'row' ? '20px' : 'initial'}
           checked={value === option}
           label={option}
           name={name}


### PR DESCRIPTION
The `RadioGroup` component used didn't have proper spacing for radio buttons inside it when displayed horizontally.
The margin between radios is 20px now, approved by @giardiv 
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/19791699/150780661-301cd390-fd9e-4287-af1b-84df141d3df6.png) | ![image](https://user-images.githubusercontent.com/19791699/150780681-8c67cc91-8b77-49f7-9a7d-413681f0df7f.png) |



