### PR TITLE
fix: make select not clickable  in disabled state

### DIFF
--- a/src/theme/select/disabled.ts
+++ b/src/theme/select/disabled.ts
@@ -4,4 +4,6 @@ export default {
   borderColor: 'transparent',
 
   cursor: 'default',
+
+  pointerEvents: 'none',
 };


### PR DESCRIPTION
When disabled, `Select2` was still clickable, even though grayed out.
It was not a right behavior.