### PR TITLE
chore: update rebass types

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/react": "^16.9.27",
     "@types/react-datepicker": "^3.1.2",
     "@types/react-dom": "^16.9.7",
-    "@types/rebass": "^4.0.6",
+    "@types/rebass": "^4.0.10",
     "@types/rebass__forms": "^4.0.4",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3464,10 +3464,20 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/rebass@*", "@types/rebass@^4.0.6":
+"@types/rebass@*":
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/@types/rebass/-/rebass-4.0.9.tgz#526b6e2ceab2b7e76e45cbeed264e250118b8036"
   integrity sha512-1GN4RF4vPpM/PTjodmqgG3rMbx+RAYqv/c6DQSmtjC6CPjpl/EPZRFh2NBkl7/2/AVeTQtWvcC609Ly6xmOVEw==
+  dependencies:
+    "@types/react" "*"
+    "@types/styled-components" "*"
+    "@types/styled-system" "*"
+    "@types/styled-system__css" "*"
+
+"@types/rebass@^4.0.10":
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/@types/rebass/-/rebass-4.0.10.tgz#f7a819d039349c138f279d2104986d7604a85528"
+  integrity sha512-Bp9Y2Bc7wrZr2NYHrqWOVRHdL5I5CRIaOiG9hlnwHH5hFRf8/FJsiJmCMsBhlsma312Jc6xWL+XUtSnfio+wOA==
   dependencies:
     "@types/react" "*"
     "@types/styled-components" "*"


### PR DESCRIPTION
The types were old. Now they're not
![image](https://user-images.githubusercontent.com/19791699/151971967-ebb62a09-9c67-49ea-9483-03bd0f3d392a.png)
