### PR TITLE
CU-1xd1xfn - Add option to specify the parent directory

### DIFF
--- a/src/components/file-system-explorer/footer/index.tsx
+++ b/src/components/file-system-explorer/footer/index.tsx
@@ -5,7 +5,7 @@ import Labeling from '../../typography/labeling';
 import { ActiveFile } from '../index';
 import Button from '../../button';
 
-export interface fileExplorerFooter {
+export interface FileExplorerFooter {
   value?: string;
   activeFile?: ActiveFile;
   onClose: (key: any) => void;
@@ -13,9 +13,10 @@ export interface fileExplorerFooter {
   columns: any[];
   handleSelectFile: (activeFile: any, isDownload: boolean) => void;
   fileListValue: Array<ActiveFile>[];
+  rootDir: string;
 }
 
-const FooterFileExplorer: FC<fileExplorerFooter> = ({
+const FooterFileExplorer: FC<FileExplorerFooter> = ({
   value,
   activeFile,
   columns,
@@ -23,26 +24,26 @@ const FooterFileExplorer: FC<fileExplorerFooter> = ({
   onClose,
   handleSelectFile,
   fileListValue,
+  rootDir,
   ...props
-}: fileExplorerFooter) => {
+}: FileExplorerFooter) => {
   const ExplorerMode = (mode: string) => {
     switch (mode) {
       case 'oneFile':
         return activeFile ? activeFile.attributes.name : 'pick a file';
 
       case 'nFiles': {
-        if (!!fileListValue.length) {
-          const newList = fileListValue.map((el: any) => {
-            return el.attributes.name;
-          });
+        if (fileListValue.length) {
+          const newList = fileListValue.map((el: any) => el.attributes.name);
           return newList.join(' ; ');
-        } else return 'pick a file';
+        }
+        return 'pick a file';
       }
 
       case 'oneFolder':
-        return !!value ? value : '/';
+        return value || rootDir;
       default:
-        return;
+        return rootDir;
     }
   };
   const ColorStyle = (mode: string) => {
@@ -51,7 +52,7 @@ const FooterFileExplorer: FC<fileExplorerFooter> = ({
         return activeFile ? 'primary' : 'gray';
 
       case 'nFiles':
-        return !!fileListValue.length ? 'primary' : 'gray';
+        return fileListValue.length ? 'primary' : 'gray';
 
       case 'oneFolder':
         return 'primary';
@@ -69,7 +70,7 @@ const FooterFileExplorer: FC<fileExplorerFooter> = ({
         return handleSelectFile(fileListValue, false);
 
       case 'oneFolder':
-        return handleSelectFile(value || '/', false);
+        return handleSelectFile(value || rootDir, false);
       default:
         return 'gray';
     }

--- a/src/components/file-system-explorer/index.tsx
+++ b/src/components/file-system-explorer/index.tsx
@@ -26,6 +26,7 @@ export interface FileSystemExplorerProps
   data: any;
   disableDownload?: boolean;
   validExtensions?: string[];
+  rootDir?: string;
   handleLoadMore: (path: string, columnIndex: number) => void;
   shortcutActions?: React.ReactNode;
   contentProps?: Omit<RebassCardProps, 'css' | 'children'>;
@@ -60,6 +61,7 @@ const FileSystemExplorer: FC<FileSystemExplorerProps> = ({
   shortcutActions,
   handleDownloadFile,
   mode = 'oneFile',
+  rootDir = '/',
   contentProps,
   handleLoadMore = () => console.log('load more in quartz'),
   handleSelectFile = () => console.log('handleSelectFile in quartz'),
@@ -169,6 +171,7 @@ const FileSystemExplorer: FC<FileSystemExplorerProps> = ({
         columns={columns}
         mode={mode}
         handleSelectFile={handleSelectFile}
+        rootDir={rootDir}
       />
     </RebassCard>
   );


### PR DESCRIPTION
Currently the file selector assumes that root is `/` - which is not true in 99% of the cases. Selection happens within the concept of a project, hence "root" is `/Projects/projectName`.

While this is most likely the case, I added an attribute to be able to control this - so that if other use cases appear and they require selection at `/` level, this is supported.