### PR TITLE
fix: add "release" into package [skip release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "release": {
+    "branches": ["dev"]
+  },
   "packageManager": "yarn@3.1.1"
 }


### PR DESCRIPTION
I messed up and lost a piece of config to deploy it from `dev` branch.
The default is `master`, so no release was made.
