### PR TITLE
feat: add support for differing key and value

### DIFF
--- a/src/components/radio/radio-group.tsx
+++ b/src/components/radio/radio-group.tsx
@@ -9,12 +9,12 @@ import randomString from '../../utils/randomString';
 export type RadioGroupOption = {
   key: string;
   text: string;
+  additionalText?: string;
 };
 export interface RadioGroupProps
   extends Omit<RadioProps, 'label' | 'onChange' | 'options' | 'value'> {
   value: string | null;
   options: string[] | RadioGroupOption[];
-  additionalTexts?: string[];
   onChange: (value: string) => void;
   tooltipMessages?: {
     [key: string]: string;
@@ -26,7 +26,6 @@ const RadioGroup: FC<RadioGroupProps> = ({
   options,
   value,
   onChange,
-  additionalTexts,
   tooltipMessages = {},
   flexDirection = 'column',
   ...props
@@ -46,7 +45,7 @@ const RadioGroup: FC<RadioGroupProps> = ({
 
   return (
     <Flex flexDirection={flexDirection}>
-      {mappedOptions?.map(({ key, text }, idx) => (
+      {mappedOptions?.map(({ key, text, additionalText }) => (
         <Radio
           {...props}
           key={key}
@@ -55,7 +54,7 @@ const RadioGroup: FC<RadioGroupProps> = ({
           checked={value === key}
           label={text}
           name={name}
-          addtionalText={additionalTexts?.[idx]}
+          addtionalText={additionalText}
           onChange={handleChange(key)}
           tooltip={tooltipMessages[key]}
         />

--- a/src/components/radio/radio-group.tsx
+++ b/src/components/radio/radio-group.tsx
@@ -6,10 +6,14 @@ import Radio, { RadioProps } from './index';
 // Utils
 import randomString from '../../utils/randomString';
 
+export type RadioGroupOption = {
+  key: string;
+  text: string;
+};
 export interface RadioGroupProps
   extends Omit<RadioProps, 'label' | 'onChange' | 'options' | 'value'> {
   value: string | null;
-  options: string[];
+  options: string[] | RadioGroupOption[];
   additionalTexts?: string[];
   onChange: (value: string) => void;
   tooltipMessages?: {
@@ -36,20 +40,24 @@ const RadioGroup: FC<RadioGroupProps> = ({
 
   const name = randomString();
 
+  const mappedOptions = options.map((val) =>
+    typeof val === 'string' ? { key: val, text: val } : val,
+  );
+
   return (
     <Flex flexDirection={flexDirection}>
-      {options?.map((option, idx) => (
+      {mappedOptions?.map(({ key, text }, idx) => (
         <Radio
           {...props}
-          key={option}
+          key={key}
           mt={flexDirection === 'column' ? 2 : 'initial'}
           mr={flexDirection === 'row' ? '20px' : 'initial'}
-          checked={value === option}
-          label={option}
+          checked={value === key}
+          label={text}
           name={name}
           addtionalText={additionalTexts?.[idx]}
-          onChange={handleChange(option)}
-          tooltip={tooltipMessages[option]}
+          onChange={handleChange(key)}
+          tooltip={tooltipMessages[key]}
         />
       ))}
     </Flex>

--- a/src/components/radio/radio.stories.tsx
+++ b/src/components/radio/radio.stories.tsx
@@ -19,12 +19,11 @@ const GroupTemplate: Story<RadioGroupProps> = (props) => {
       onChange={setValue}
       mr="auto"
       options={[
-        { key: 'nullable', text: 'nullable' },
-        { key: 'required', text: 'REQUIRED' },
+        { key: 'nullable', text: 'nullable', additionalText: 'text1' },
+        { key: 'required', text: 'REQUIRED', additionalText: 'text2' },
         { key: 'email', text: 'email' },
         { key: 'url', text: 'url' },
       ]}
-      additionalTexts={['text1', 'text2', 'text3', 'text4']}
     />
   );
 };

--- a/src/components/radio/radio.stories.tsx
+++ b/src/components/radio/radio.stories.tsx
@@ -56,7 +56,7 @@ Group.argTypes = {
   },
   options: {
     type: {
-      summary: 'Array of strings',
+      summary: 'Array of strings or Array of { key, text }',
       required: true,
     },
   },

--- a/src/components/radio/radio.stories.tsx
+++ b/src/components/radio/radio.stories.tsx
@@ -18,7 +18,12 @@ const GroupTemplate: Story<RadioGroupProps> = (props) => {
       value={value}
       onChange={setValue}
       mr="auto"
-      options={['nullable', 'required', 'email', 'url']}
+      options={[
+        { key: 'nullable', text: 'nullable' },
+        { key: 'required', text: 'REQUIRED' },
+        { key: 'email', text: 'email' },
+        { key: 'url', text: 'url' },
+      ]}
       additionalTexts={['text1', 'text2', 'text3', 'text4']}
     />
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,7 +263,8 @@ export type { ITheme, IThemeColors, IThemeIconSizes } from './theme/types';
 export type TooltipProps = import('./components/tooltip').TooltipProps;
 export type BadgeProps = import('./components/badges').BadgeProps;
 export type SliderProps = import('./components/slider').SliderProps;
-export type RangeSliderProps = import('./components/range-slider').RangeSliderProps;
+export type RangeSliderProps =
+  import('./components/range-slider').RangeSliderProps;
 export type EditableSelectProps =
   import('./components/editableSelect').EditableSelectProps;
 export type Select2Props = import('./components/select2').SelectProps;
@@ -290,6 +291,11 @@ export type { CardHeaderProps } from './components/card-header';
 export type { FileSystemExplorerProps } from './components/file-system-explorer';
 export type { FileExplorData } from './components/file-system-explorer/types';
 export type { GetIconProps } from './components/icon/GetIcon';
+export type { RadioProps } from './components/radio';
+export type {
+  RadioGroupProps,
+  RadioGroupOption,
+} from './components/radio/radio-group';
 
 // Rebass components
 export { Flex, Box } from 'rebass';


### PR DESCRIPTION
Updating radio group to accept options as 
```ts
{ key: string, text: string }
```
The selected value would be based on the `key` but we show `text` in the UI

BREAKING CHANGE:
Removed `additionalTexts` property and reimplemented it in the same options array.
it's safe since we are not using it anywhere in hopsworks