### PR TITLE
fix: ci build failing silently.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "http://logicalclocks.github.io/quartz",
   "name": "@logicalclocks/quartz",
-  "version": "2.0.0",
+  "version": "1.4.1",
   "description": "Logical Clocks Design System Library",
   "author": "logicalclocks",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "http://logicalclocks.github.io/quartz",
   "name": "@logicalclocks/quartz",
-  "version": "1.4.1",
+  "version": "1.5.1",
   "description": "Logical Clocks Design System Library",
   "author": "logicalclocks",
   "license": "MIT",
@@ -111,6 +111,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "resolutions": {
+    "npm/chalk": "^4.1.2"
   },
   "packageManager": "yarn@3.1.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7764,13 +7764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:*, chalk@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "chalk@npm:5.0.1"
-  checksum: 7b45300372b908f0471fbf7389ce2f5de8d85bb949026fd51a1b95b10d0ed32c7ed5aab36dd5e9d2bf3191867909b4404cef75c5f4d2d1daeeacd301dd280b76
-  languageName: node
-  linkType: hard
-
 "chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.0.1, chalk@npm:^2.1.0, chalk@npm:^2.3.2, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -7802,6 +7795,13 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "chalk@npm:5.0.1"
+  checksum: 7b45300372b908f0471fbf7389ce2f5de8d85bb949026fd51a1b95b10d0ed32c7ed5aab36dd5e9d2bf3191867909b4404cef75c5f4d2d1daeeacd301dd280b76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As you know, releases for semantic have been working just fine.
But not for `npm`.
I think, I've found the reason: it was `chalk` dependency which silently broke the build.
Thought it was warning and it's alright, but there is an issue about this, so seems like we're not the only people with this problem.
https://github.com/semantic-release/semantic-release/issues/2323

I think this should fix it.