### PR TITLE
feat: useTheme with typings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ import * as constants from './constants';
 
 library.add(fas, far);
 
-export { useTheme } from 'emotion-theming';
+export { default as useTheme } from './theme/useTheme';
 
 export {
   Button,

--- a/src/theme/useTheme.ts
+++ b/src/theme/useTheme.ts
@@ -1,0 +1,5 @@
+import { useTheme as useEmotionTheme } from 'emotion-theming';
+import { ITheme } from './types';
+
+const useTheme = useEmotionTheme as () => ITheme;
+export default useTheme;


### PR DESCRIPTION
Right now we use `emotion-theming` as a dependency in our projects alongside with `quartz`.
We had a `useTheme` available from `quartz`, but this would require

`import { useTheme, ITheme } from '@logicalclocks/quartz`
and then using as
`const theme = useTheme<ITheme>();`
but essentially, they both come from one place, so I decided to simplify this process for the end user.

now it is gonna be

```typescript
import { useTheme } from '@logicalclocks/quartz
// some code here
const theme = useTheme();
```

because it's not really OK to import the type and put it inside generic every single time, provided we use `quartz` as our UI kit.