### PR TITLE
revert: remove external configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "build": "microbundle --compress --format modern,cjs --jsx React.createElement --external react,react-dom",
-    "build-dev": "microbundle --no-compress --format modern,cjs --jsx React.createElement --external react,react-dom",
+    "build": "microbundle --compress --format modern,cjs --jsx React.createElement",
+    "build-dev": "microbundle --no-compress --format modern,cjs --jsx React.createElement",
     "start": "microbundle watch --no-compress --format modern,cjs --jsx React.createElement",
     "prepare": "run-s build",
     "prepack": "run-s build",


### PR DESCRIPTION
 `--external` flag is redundant, as `microbundle` uses `react` as external dependency anyways. But passing `--external`
makes `microbundle` ignore everything besides passed `react`, inlining all other libraries we use, thus increasing the bundle size to ~600-800kb(from 60-80)

![image](https://user-images.githubusercontent.com/19791699/163577965-10e15e71-0723-466e-a50e-34a33b3760b4.png)

line of code in `microbundle`

![image](https://user-images.githubusercontent.com/19791699/163578010-def355c3-0049-424f-a3f9-f742d62e507d.png)
