### PR TITLE
build: add `yalc` publishing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,10 @@ Delete `node_modules` and `dist` folders then follow **Build locally** or **Run 
 ## On repo update
 
 Follow **Build locally** or **Run locally** instruction
+
+
+## Using locally
+You can use the library locally with the help of [yalc](https://github.com/wclr/yalc).
+Just run `yarn publish-local` here and then do a `yalc link @logicalclocks/quartz` wherever you wanna use it.
+
+To publish changes you can do `yarn dlx yalc push`. After that, the changes will be "published" to the local registry.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "storybook": "start-storybook -p 6006",
     "chromatic": "npx chromatic --project-token dqq8k95raoo",
     "semantic-release": "semantic-release",
-    "commit": "cz"
+    "commit": "cz",
+    "publish-local": "yarn dlx yalc publish"
   },
   "peerDependencies": {
     "react": "^16.14.0",


### PR DESCRIPTION
This PR introduces [yalc](https://github.com/wclr/yalc).
It's a tool for the libraries like quartz. 
It's basically a local npm registry. You can publish things here and then add then link them properly.

Why this over `yarn link`?
There is a commonly known problem of [duplicate react versions](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) when using links.

And this thing solves the problem with one script addition.

There'll be another PR in the `hopsworks-frontend`.