### PR TITLE
feat: customizable holy table

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "chromatic": "npx chromatic --project-token dqq8k95raoo",
     "semantic-release": "semantic-release",
     "commit": "cz",
-    "publish-local": "yarn dlx yalc publish"
+    "publish-local": "yalc publish --push",
+    "push-local": "yalc push"
   },
   "peerDependencies": {
     "react": "^16.14.0",
@@ -83,7 +84,8 @@
     "react-dom": "^16.14.0",
     "react-scripts": "^3.4.1",
     "semantic-release": "^19.0.2",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.2",
+    "yalc": "^1.0.0-pre.53"
   },
   "files": [
     "dist",

--- a/src/components/holy-table/head-cell/head-cell.tsx
+++ b/src/components/holy-table/head-cell/head-cell.tsx
@@ -1,20 +1,16 @@
-import React, { ReactNode, useContext } from 'react';
+import React, { ReactNode } from 'react';
 import { BoxProps } from 'rebass';
 import Labeling from '../../typography/labeling';
-import HolyTableContext from '../holy-table.context';
 import styles from './styles';
 
 interface Props extends Omit<BoxProps, 'css'> {
-  index: number;
+  fillSpace?: boolean;
   children: ReactNode;
 }
 
-const HeadCell = ({ sx, index, children, ...props }: Props) => {
-  const { middleColumn } = useContext(HolyTableContext);
-  const shouldCellFillSpace = index === middleColumn;
-
+const HeadCell = ({ sx, fillSpace = false, children, ...props }: Props) => {
   return (
-    <Labeling as="th" gray pb="4px" sx={styles(shouldCellFillSpace)} {...props}>
+    <Labeling as="th" gray pb="4px" sx={styles(fillSpace)} {...props}>
       {children}
     </Labeling>
   );

--- a/src/components/holy-table/holy-table.stories.tsx
+++ b/src/components/holy-table/holy-table.stories.tsx
@@ -1,32 +1,60 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React from 'react';
 import { Box } from 'rebass';
-import HolyTable from '.';
+import { default as HT } from '.';
 import { Props } from './holy-table';
 
 export default {
   title: 'Quartz/HolyTable',
-  component: HolyTable,
+  component: HT,
 } as Meta;
 
-export const HolyTableExample: Story = (props: Omit<Props, 'children'>) => (
+export const HolyTableWithLegend: Story = (props: Omit<Props, 'children'>) => (
   <Box width="700px">
-    <HolyTable {...props} legend={['name', 'hex', 'rgb']}>
-      <HolyTable.Row>
-        <HolyTable.Cell>Black</HolyTable.Cell>
-        <HolyTable.Cell>#000000</HolyTable.Cell>
-        <HolyTable.Cell>0, 0, 0</HolyTable.Cell>
-      </HolyTable.Row>
-      <HolyTable.Row>
-        <HolyTable.Cell>White</HolyTable.Cell>
-        <HolyTable.Cell>#ffffff</HolyTable.Cell>
-        <HolyTable.Cell>255, 255, 255</HolyTable.Cell>
-      </HolyTable.Row>
-    </HolyTable>
+    <HT {...props} legend={['name', 'hex', 'rgb']}>
+      <HT.Row>
+        <HT.Cell>Black</HT.Cell>
+        <HT.Cell>#000000</HT.Cell>
+        <HT.Cell>0, 0, 0</HT.Cell>
+      </HT.Row>
+      <HT.Row>
+        <HT.Cell>White</HT.Cell>
+        <HT.Cell>#ffffff</HT.Cell>
+        <HT.Cell>255, 255, 255</HT.Cell>
+      </HT.Row>
+    </HT>
   </Box>
 );
 
-HolyTableExample.args = {
+export const HolyTableCustom: Story = (
+  props: Omit<Props, 'children' | 'legend'>,
+) => (
+  <Box width="700px">
+    <HT {...props}>
+      <thead style={{ background: 'magenta' }}>
+        <tr>
+          <HT.HeadCell>Name</HT.HeadCell>
+          <HT.HeadCell>hex</HT.HeadCell>
+          <HT.HeadCell>rgb</HT.HeadCell>
+        </tr>
+      </thead>
+      <tbody>
+        <HT.Row>
+          <HT.Cell>Black</HT.Cell>
+          <HT.Cell>#000000</HT.Cell>
+          <HT.Cell>0, 0, 0</HT.Cell>
+        </HT.Row>
+        <HT.Row>
+          <HT.Cell>White</HT.Cell>
+          <HT.Cell>#ffffff</HT.Cell>
+          <HT.Cell>255, 255, 255</HT.Cell>
+        </HT.Row>
+      </tbody>
+    </HT>
+  </Box>
+);
+
+const args = {
   standalone: false,
   padded: true,
   bordered: true,
@@ -34,7 +62,7 @@ HolyTableExample.args = {
   rowHeight: '50px',
 };
 
-HolyTableExample.argTypes = {
+const argTypes = {
   standalone: {
     control: {
       type: 'boolean',
@@ -85,3 +113,9 @@ HolyTableExample.argTypes = {
     },
   },
 };
+
+HolyTableWithLegend.args = args;
+HolyTableWithLegend.argTypes = argTypes;
+
+HolyTableCustom.args = args;
+HolyTableCustom.argTypes = argTypes;

--- a/src/components/holy-table/holy-table.tsx
+++ b/src/components/holy-table/holy-table.tsx
@@ -30,20 +30,29 @@ const HolyTable: FC<Props> = ({
     value={{ bordered, padded, hoverable, middleColumn, rowHeight, standalone }}
   >
     <Box as="table" sx={styles} {...props}>
-      {legend && (
-        <Box as="thead">
-          <Box as="tr" width="100%">
-            {legend.map((name, index) => (
-              // there was no other way for generating keys :()
-              // eslint-disable-next-line react/no-array-index-key
-              <HeadCell key={name + index} index={index}>
-                {name}
-              </HeadCell>
-            ))}
+      {legend ? (
+        /* the logic is that if there is a `legend`, then this is a very simple table and we can insert `tbody` and `thead`.//
+           otherwise, we want to be able to put our own `thead` and `tbody` with custom children
+
+           so, there are two ways to do this:
+        */
+        <>
+          <Box as="thead">
+            <Box as="tr" width="100%">
+              {legend.map((name, index) => (
+                // there was no other way for generating keys :()
+                // eslint-disable-next-line react/no-array-index-key
+                <HeadCell key={name + index} fillSpace={middleColumn === index}>
+                  {name}
+                </HeadCell>
+              ))}
+            </Box>
           </Box>
-        </Box>
+          <Box as="tbody">{children}</Box>
+        </>
+      ) : (
+        children
       )}
-      <Box as="tbody">{children}</Box>
     </Box>
   </HolyTableContext.Provider>
 );

--- a/src/components/holy-table/holy-table.tsx
+++ b/src/components/holy-table/holy-table.tsx
@@ -30,8 +30,8 @@ const HolyTable: FC<Props> = ({
     value={{ bordered, padded, hoverable, middleColumn, rowHeight, standalone }}
   >
     <Box as="table" sx={styles} {...props}>
-      <Box as="thead">
-        {legend && (
+      {legend && (
+        <Box as="thead">
           <Box as="tr" width="100%">
             {legend.map((name, index) => (
               // there was no other way for generating keys :()
@@ -41,8 +41,8 @@ const HolyTable: FC<Props> = ({
               </HeadCell>
             ))}
           </Box>
-        )}
-      </Box>
+        </Box>
+      )}
       <Box as="tbody">{children}</Box>
     </Box>
   </HolyTableContext.Provider>

--- a/src/components/holy-table/index.tsx
+++ b/src/components/holy-table/index.tsx
@@ -1,14 +1,17 @@
 import Cell from './cell/cell';
 import Row from './row';
 import HolyTable from './holy-table';
+import HeadCell from './head-cell';
 
 type IHolyTable = typeof HolyTable;
 
 interface HolyTableComponent extends IHolyTable {
+  HeadCell: typeof HeadCell;
   Cell: typeof Cell;
   Row: typeof Row;
 }
 
+(HolyTable as HolyTableComponent).HeadCell = HeadCell;
 (HolyTable as HolyTableComponent).Cell = Cell;
 (HolyTable as HolyTableComponent).Row = Row;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,6 +2526,7 @@ __metadata:
     resize-observer-polyfill: ^1.5.1
     semantic-release: ^19.0.2
     typescript: ^4.6.2
+    yalc: ^1.0.0-pre.53
   peerDependencies:
     react: ^16.14.0
     react-dom: ^16.14.0
@@ -9765,6 +9766,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-indent@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "detect-indent@npm:6.1.0"
+  checksum: ab953a73c72dbd4e8fc68e4ed4bfd92c97eb6c43734af3900add963fd3a9316f3bc0578b018b24198d4c31a358571eff5f0656e81a1f3b9ad5c547d58b2d093d
+  languageName: node
+  linkType: hard
+
 "detect-newline@npm:^2.1.0":
   version: 2.1.0
   resolution: "detect-newline@npm:2.1.0"
@@ -12016,7 +12024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:8.1.0, fs-extra@npm:^8.1.0":
+"fs-extra@npm:8.1.0, fs-extra@npm:^8.0.1, fs-extra@npm:^8.1.0":
   version: 8.1.0
   resolution: "fs-extra@npm:8.1.0"
   dependencies:
@@ -13364,6 +13372,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore-walk@npm:^3.0.3":
+  version: 3.0.4
+  resolution: "ignore-walk@npm:3.0.4"
+  dependencies:
+    minimatch: ^3.0.4
+  checksum: 9e9c5ef6c3e0ed7ef5d797991abb554dbb7e60d5fedf6cf05c7129819689eba2b462f625c6e3561e0fc79841904eb829565513eeeab1b44f4fbec4d3146b1a8d
+  languageName: node
+  linkType: hard
+
 "ignore-walk@npm:^4.0.1":
   version: 4.0.1
   resolution: "ignore-walk@npm:4.0.1"
@@ -13387,7 +13404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.1, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
+"ignore@npm:^5.0.4, ignore@npm:^5.1.1, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
@@ -17398,6 +17415,20 @@ __metadata:
     semver: ^7.3.5
     validate-npm-package-name: ^4.0.0
   checksum: 07828f330f611214a0aa1e87f402b30b3dc90388671470ad8dc1551f28b0cb886f1f75fa7c37e894a9598640a555c05643642994ecacb9a6c68f655e571968f7
+  languageName: node
+  linkType: hard
+
+"npm-packlist@npm:^2.1.5":
+  version: 2.2.2
+  resolution: "npm-packlist@npm:2.2.2"
+  dependencies:
+    glob: ^7.1.6
+    ignore-walk: ^3.0.3
+    npm-bundled: ^1.1.1
+    npm-normalize-package-bin: ^1.0.1
+  bin:
+    npm-packlist: bin/index.js
+  checksum: 799ce94b077e4dc366a9a5bcc5f006669263bb1a48d6948161aed915fd2f11dea8a7cf516a63fc78e5df059915591dade5928f0738baadc99a8ab4685d8b58c3
   languageName: node
   linkType: hard
 
@@ -25651,6 +25682,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yalc@npm:^1.0.0-pre.53":
+  version: 1.0.0-pre.53
+  resolution: "yalc@npm:1.0.0-pre.53"
+  dependencies:
+    chalk: ^4.1.0
+    detect-indent: ^6.0.0
+    fs-extra: ^8.0.1
+    glob: ^7.1.4
+    ignore: ^5.0.4
+    ini: ^2.0.0
+    npm-packlist: ^2.1.5
+    yargs: ^16.1.1
+  bin:
+    yalc: src/yalc.js
+  checksum: 3421e20039909fd0497e43ec05278e9f661d2300506deeaf06d8698e2f4dd37f905a267e85ec51e29811fd3d3844051172f4bb31049113774d502a69b0ecf2a1
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^3.0.2":
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
@@ -25689,7 +25738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:16.2.0, yargs@npm:^16.2.0":
+"yargs@npm:16.2.0, yargs@npm:^16.1.1, yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
This PR makes `HolyTable` a bit more customizable.
Basically there are now 2 scenarios:
1. `legend` is passed, the usage is very simple. Put a legend, build rows. 
Basically this
```jsx
    <HT legend={['name', 'hex', 'rgb']} standalone>
      <HT.Row>
        <HT.Cell>Black</HT.Cell>
        <HT.Cell>#000000</HT.Cell>
        <HT.Cell>0, 0, 0</HT.Cell>
      </HT.Row>
    </HT>
```
2. no `legend` is passed. Then the user puts their own `thead` and `tbody`. In this mode `HolyTable` is a mere styling option, but you still preserve props like `bordered`, `padded`, which is quite neat I think 😄 
The example is with `react-table`
```jsx
<HolyTable bordered={false} hoverable={false}>
  <thead>
    {headerGroups.map((headerGroup) => (
      <tr {...headerGroup.getHeaderGroupProps()}>
        {headerGroup.headers.map((column, index) => (
          <HolyTable.HeadCell
            index={index}
            {...column.getHeaderProps(column.getSortByToggleProps())}
          >
            <Flex as="span" alignItems="center">
              {column.render("Header")}{" "}
              <SortIcons
                isSorted={column.isSorted}
                isSortedDesc={Boolean(column.isSortedDesc)}
              />
            </Flex>
          </HolyTable.HeadCell>
        ))}
      </tr>
    ))}
  </thead>
  <tbody {...getTableBodyProps()}>
    {rows.map((row, i) => {
      prepareRow(row);
      return (
        <HolyTable.Row {...row.getRowProps()}>
          {row.cells.map((cell) => {
            return (
              <HolyTable.Cell {...cell.getCellProps()}>
                {cell.render("Cell")}
              </HolyTable.Cell>
            );
          })}
        </HolyTable.Row>
      );
    })}
  </tbody>
</HolyTable>;

```

![image](https://user-images.githubusercontent.com/19791699/168847024-d8591a27-edb1-4f2e-abef-3ad05fa1ac0b.png)



P.S.

This PR also adds a local installation of `yalc`, as it's just much faster this way rather than relying on `yarn dlx`