### PR TITLE
feat: controlled embedded tab

### DIFF
--- a/src/components/embedded-tabs/EmbeddedTabs.tsx
+++ b/src/components/embedded-tabs/EmbeddedTabs.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, BoxProps } from 'rebass';
 import * as S from './styles';
 import Tab, { Props as EmbeddedTabItem } from './Tab';
@@ -9,13 +9,7 @@ export interface Props extends Omit<BoxProps, 'css'> {
   onTabChange?: (tabIndex: number) => void;
 }
 
-const EmbeddedTabs: FC<Props> = ({
-  tabs,
-  onTabChange,
-  initialTab = 0,
-  sx = {},
-  ...boxProps
-}: Props) => {
+const EmbeddedTabs = ({ onTabChange, initialTab = 0, ...restProps }: Props) => {
   const [activeIndex, setActiveIndex] = useState(initialTab);
 
   const handleTabClick = (newIndex: number) => {
@@ -27,12 +21,40 @@ const EmbeddedTabs: FC<Props> = ({
   };
 
   return (
+    <Controlled
+      activeTab={activeIndex}
+      onTabChange={handleTabClick}
+      {...restProps}
+    />
+  );
+};
+
+export default EmbeddedTabs;
+
+export interface ControlledProps extends Omit<Props, 'initialTab'> {
+  activeTab: number;
+}
+
+export const Controlled = ({
+  tabs,
+  onTabChange,
+  sx = {},
+  activeTab,
+  ...boxProps
+}: ControlledProps) => {
+  const handleTabClick = (newIndex: number) => {
+    if (onTabChange) {
+      onTabChange(newIndex);
+    }
+  };
+
+  return (
     <Box sx={{ ...S.tabsList, ...sx }} {...boxProps}>
       {tabs.map(({ title, onClick: onTabClick, ...tabProps }, index) => (
         <Tab
           key={title}
           title={title}
-          active={index === activeIndex}
+          active={index === activeTab}
           onClick={() => {
             if (onTabClick) {
               onTabClick();
@@ -48,5 +70,3 @@ const EmbeddedTabs: FC<Props> = ({
     </Box>
   );
 };
-
-export default EmbeddedTabs;

--- a/src/components/embedded-tabs/embedded-tabs.stories.tsx
+++ b/src/components/embedded-tabs/embedded-tabs.stories.tsx
@@ -1,11 +1,13 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React, { useState } from 'react';
-import { Box } from 'rebass';
+import { Box, Flex } from 'rebass';
 import Labeling from '../typography/labeling';
 import EmbeddedTabs, {
   EmbeddedTabsProps,
   ControlledEmbeddedTabsProps,
 } from '.';
+import Button from '../button';
+import Subtitle from '../typography/subtitle';
 
 export default {
   title: 'Quartz/EmbeddedTabs',
@@ -53,7 +55,13 @@ export const Controlled: Story<ControlledEmbeddedTabsProps> = (props) => {
         onTabChange={setActiveTab}
       />
       <Box mt={3}>
-        <Labeling bold>Active tab: {tabs[activeTab].title}</Labeling>
+        <Labeling bold>
+          This component is controlled. Active tab: {tabs[activeTab].title}{' '}
+        </Labeling>
+        <Flex mt={2} sx={{ gap: '10px' }}>
+          <Button onClick={() => setActiveTab(2)}>Jump to Statistics</Button>
+          <Button onClick={() => setActiveTab(1)}>Jump to Results</Button>
+        </Flex>
       </Box>
     </Box>
   );

--- a/src/components/embedded-tabs/embedded-tabs.stories.tsx
+++ b/src/components/embedded-tabs/embedded-tabs.stories.tsx
@@ -2,28 +2,16 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 import React, { useState } from 'react';
 import { Box } from 'rebass';
 import Labeling from '../typography/labeling';
-import EmbeddedTabs, { Props } from './EmbeddedTabs';
+import EmbeddedTabs, {
+  EmbeddedTabsProps,
+  ControlledEmbeddedTabsProps,
+} from '.';
 
 export default {
   title: 'Quartz/EmbeddedTabs',
   component: EmbeddedTabs,
+  subcomponents: { Controlled: EmbeddedTabs.Controlled },
 } as Meta;
-
-const argTypes = {
-  tabs: {
-    required: true,
-    description: 'A list of tab items.',
-  },
-  initialTab: {
-    required: false,
-    description: 'The initial tab to be selected.',
-    default: 0,
-  },
-  onTabChange: {
-    description: 'Callback to be called when a tab is selected.',
-    required: false
-  },
-};
 
 const tabs = [
   {
@@ -41,7 +29,7 @@ const tabs = [
   },
 ];
 
-const Template: Story<Props> = (props) => {
+export const Uncontrolled: Story<EmbeddedTabsProps> = (props) => {
   const [activeTab, setActiveTab] = useState(props.initialTab ?? 0);
 
   return (
@@ -54,10 +42,45 @@ const Template: Story<Props> = (props) => {
   );
 };
 
-export const Default = Template.bind({});
+export const Controlled: Story<ControlledEmbeddedTabsProps> = (props) => {
+  const [activeTab, setActiveTab] = useState(0);
 
-Default.args = {
+  return (
+    <Box width="700px">
+      <EmbeddedTabs.Controlled
+        {...props}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
+      <Box mt={3}>
+        <Labeling bold>Active tab: {tabs[activeTab].title}</Labeling>
+      </Box>
+    </Box>
+  );
+};
+
+const args = {
   tabs,
 };
 
-Default.argTypes = argTypes;
+const argTypes = {
+  tabs: {
+    required: true,
+    description: 'A list of tab items.',
+  },
+  initialTab: {
+    required: false,
+    description: 'The initial tab to be selected.',
+    default: 0,
+  },
+  onTabChange: {
+    description: 'Callback to be called when a tab is selected.',
+    required: false,
+  },
+};
+
+Uncontrolled.args = args;
+Uncontrolled.argTypes = argTypes;
+
+Controlled.args = args;
+Controlled.argTypes = argTypes;

--- a/src/components/embedded-tabs/index.ts
+++ b/src/components/embedded-tabs/index.ts
@@ -1,3 +1,14 @@
-export { default } from './EmbeddedTabs';
-export type { Props as EmbeddedTabsProps } from './EmbeddedTabs';
 export type { Props as EmbeddedTabsItem } from './Tab';
+
+import EmbeddedTabs, { Controlled } from './EmbeddedTabs';
+
+type IEmbeddedTabs = typeof EmbeddedTabs;
+
+interface EmbeddedTabsComponent extends IEmbeddedTabs {
+  Controlled: typeof Controlled;
+}
+
+(EmbeddedTabs as EmbeddedTabsComponent).Controlled = Controlled;
+
+export type { Props as EmbeddedTabsProps, ControlledProps as ControlledEmbeddedTabsProps } from './EmbeddedTabs';
+export default EmbeddedTabs as EmbeddedTabsComponent;


### PR DESCRIPTION
This PR adds a controlled variant for embedded tab.
Basically, it allows user to specify `activeTab`, thus making a component controllable from outside.
Useful when you have programmatic tab changes.
The usage is as follows:
```jsx
<EmbeddedTabs.Controlled ...{props} />
```

### Demo
https://user-images.githubusercontent.com/19791699/168869481-d3e3f963-5401-44e5-ac04-559a6d3335e4.mp4


