### PR TITLE
feat: add `sx` extension

### DIFF
--- a/src/components/card/card-secondary.tsx
+++ b/src/components/card/card-secondary.tsx
@@ -49,7 +49,7 @@ const CardSecondary: FC<CardSecondaryProps> = ({
       maxHeight={maxHeight}
       tx="variants"
       variant={readOnly ? 'readOnly' : 'card'}
-      sx={styles}
+      sx={{ ...styles, ...props.sx }}
     >
       {isShowHeader && (
         <Box sx={cardHeaderStyles}>


### PR DESCRIPTION
The `CardSecondary` card had no interface to style with `sx` prop.
Added that.