### PR TITLE
fix: change event from `blur` to `mouseLeave`

### DIFF
--- a/src/components/table/editable/blur-input.tsx
+++ b/src/components/table/editable/blur-input.tsx
@@ -6,6 +6,14 @@ interface TInputProps extends Omit<InputProps, 'onChange'> {
   defaultValue: string;
 }
 
+/**
+ * @deprecated this component does not serve much purpose, its scope is limited
+ * also, it usese `onMouseLeave` instead of `onBlur` due to `blur` event blocking outside clicks
+ * references:
+ * https://github.com/jaredpalmer/formik/issues/786
+ * https://github.com/facebook/react/issues/2291
+ * https://erikmartinjordan.com/onblur-prevents-onclick-react
+ */
 const BlurInput: FC<TInputProps> = ({ defaultValue, onChange, ...props }) => {
   const [value, setValue] = useState(defaultValue);
 
@@ -16,16 +24,19 @@ const BlurInput: FC<TInputProps> = ({ defaultValue, onChange, ...props }) => {
     [],
   );
 
-  const handleBlur = useCallback(() => {
-    if (value !== defaultValue) {
-      onChange(value);
-    }
+  const handleBlur = useCallback(
+    () => {
+      if (value !== defaultValue) {
+        onChange(value);
+      }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+    [value],
+  );
 
   return (
     <Input
-      onBlur={handleBlur}
+      onMouseLeave={handleBlur}
       onChange={handleChange}
       value={value}
       {...props}


### PR DESCRIPTION
This PR fixes issue specified in https://hopsworks.atlassian.net/browse/HFRONT-647

The issue was that after you type some things to the input(`BlurInput`), and try to click on the select/checkbox, the `click` would kinda not work
The issue is that `onClick` has a lower priority than `onBlur` and it gets "eaten up" as if never happened
This issue is best described [here](https://erikmartinjordan.com/onblur-prevents-onclick-react)

This solution is hacky, indeed, but it works fine. The limitation could be when the user uses tabs, but `tabIndex`-es are broken anyways :rofl:. And even in that case, the mouse is eventually going out and we're gonna be fine.

Did a deprecation too, because `BlurInput` itself was a hack to prevent constant re-renders in a `EditableTable` component
so the whole pipeline is broken imo, but I didn't wanna go and fix it from ground up in this ticket.
Note: `BlurInput` is used only in two files at hops side.

Bug:


https://user-images.githubusercontent.com/19791699/197769969-cadac03c-1a63-40c3-a7c7-7a9f058c8db6.mp4

Fixed:


https://user-images.githubusercontent.com/19791699/197769988-bc00588a-a3d9-4445-ab01-964ad060e11e.mp4

