### PR TITLE
fix: flex `gap` property is optional

### DIFF
--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -2,7 +2,7 @@ import React, { FC, forwardRef } from 'react';
 import { Flex as RebassFlex, FlexProps } from 'rebass';
 
 export interface Props extends Omit<FlexProps, 'css'> {
-  gap: string;
+  gap?: string;
 }
 
 export const Flex: FC<Props> = forwardRef(


### PR DESCRIPTION
it was a mislook :(