### PR TITLE
fix: theme build error

### DIFF
--- a/src/theme/select/index.ts
+++ b/src/theme/select/index.ts
@@ -8,4 +8,4 @@ const variants = {
   white,
 };
 
-export default variants;
+export default variants as any;


### PR DESCRIPTION
Fixes this

![image](https://user-images.githubusercontent.com/19791699/206735653-18159c31-d36b-43e7-a95a-83e445a5dee1.png)

why `as any`?
Because types are messed up in styled system