### PR TITLE
fix: make `Bar` support infinity values

### DIFF
--- a/src/components/bar/Bar.tsx
+++ b/src/components/bar/Bar.tsx
@@ -3,6 +3,8 @@ import { Box, BoxProps } from '../box';
 import { Flex } from '../flex';
 import Value from '../typography/value';
 
+import * as R from 'ramda';
+
 export interface Props extends Omit<BoxProps, 'css'> {
   /** width of the bar */
   width?: string;
@@ -26,7 +28,12 @@ export const Bar = ({
       width={width}
       sx={outside}
     >
-      <Box as="span" bg="black" width={`${value}%`} sx={inside} />
+      <Box
+        as="span"
+        bg="black"
+        width={`${R.clamp(0, 100, value)}%`}
+        sx={inside}
+      />
     </Box>
     {hasCaption && (
       <Value fontFamily="IBM Plex Mono" fontSize="11px">

--- a/src/components/bar/Bar.tsx
+++ b/src/components/bar/Bar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import * as R from 'ramda';
+
 import { Box, BoxProps } from '../box';
 import { Flex } from '../flex';
 import Value from '../typography/value';
-
-import * as R from 'ramda';
 
 export interface Props extends Omit<BoxProps, 'css'> {
   /** width of the bar */


### PR DESCRIPTION
The `Bar` component used to break with `Infinity` supplied as a value, as it tried to do `width: Infinity%`, as it's not a correct CSS
fixed that with clamping