### PR TITLE
fix: use chakra's dark mode

### DIFF
--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,6 +1,7 @@
+import { ColorModeScript, useColorMode } from '@chakra-ui/react';
 import { css, Global } from '@emotion/core';
 import { ThemeProvider as EmotionThemeProvider } from 'emotion-theming';
-import React, { createContext, FC, useEffect, useMemo, useState } from 'react';
+import React, { FC } from 'react';
 
 import defaultTheme, { darkTheme } from './theme';
 
@@ -15,47 +16,26 @@ const ThemeProvider: FC<ThemeProviderProps> = ({
   children,
   colorMode: colorModeFromProps,
 }: ThemeProviderProps) => {
-  const [colorMode, setColorMode] = useState<ThemeVariant>(
-    (localStorage.getItem('color-mode') ?? 'light') as ThemeVariant,
-  );
-  const value = useMemo(() => ({ colorMode, setColorMode }), [colorMode]);
-
-  useEffect(
-    function syncWithLocalStorage() {
-      localStorage.setItem('color-mode', colorMode);
-    },
-    [colorMode],
-  );
+  const { colorMode } = useColorMode();
 
   const colorModeToUse = colorModeFromProps ?? colorMode; // the outer one overrides inner state
 
   return (
     <React.Fragment>
+      <ColorModeScript />
       <Global
         styles={css`
           @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap');
           @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@700&display=swap');
         `}
       />
-      <ColorModeContext.Provider value={value}>
-        <EmotionThemeProvider
-          theme={colorModeToUse === 'light' ? defaultTheme : darkTheme}
-        >
-          {children}
-        </EmotionThemeProvider>
-      </ColorModeContext.Provider>
+      <EmotionThemeProvider
+        theme={colorModeToUse === 'light' ? defaultTheme : darkTheme}
+      >
+        {children}
+      </EmotionThemeProvider>
     </React.Fragment>
   );
 };
 
 export default ThemeProvider;
-
-export interface IColorModeContext {
-  colorMode: ThemeVariant;
-  setColorMode: (mode: ThemeVariant) => void;
-}
-
-export const ColorModeContext = createContext<IColorModeContext>({
-  colorMode: 'light',
-  setColorMode: () => {},
-});

--- a/src/theme/useColorMode.ts
+++ b/src/theme/useColorMode.ts
@@ -1,14 +1,7 @@
-import { useContext } from 'react';
-import { ColorModeContext } from './ThemeProvider';
+import { useColorMode as useChakraColorMode } from '@chakra-ui/react';
 
 export const useColorMode = () => {
-  const { colorMode, setColorMode: setColorModeInContext } =
-    useContext(ColorModeContext);
+  const { colorMode, setColorMode, toggleColorMode } = useChakraColorMode();
 
-  const toggleColorMode = () => {
-    const nextColor = colorMode === 'light' ? 'dark' : 'light';
-    setColorModeInContext(nextColor);
-  };
-
-  return { colorMode, changeColorMode: setColorModeInContext, toggleColorMode };
+  return { colorMode, changeColorMode: setColorMode, toggleColorMode };
 };


### PR DESCRIPTION
## The problem
Because we had two separate "dark mode" implementations: 
one of our own in quartz/rebass, 
and the other from chakra,

these wouldn't stack well and the scrollbars for example could be dark, while the app is light, because former were controlled by chakra.

### Before
![image](https://user-images.githubusercontent.com/19791699/234354694-d530e6dd-7efe-4524-990e-1f4a36245454.png)

### After
![image](https://user-images.githubusercontent.com/19791699/234354637-826aecf8-6948-49e9-acb1-9f53174f59f9.png)
![image](https://user-images.githubusercontent.com/19791699/234354994-050605a7-f333-4b7f-b6c9-1403f24cbbc9.png)
