### PR TITLE
feat(CodeInput): add `json` mode

### DIFF
--- a/src/components/code-input/index.tsx
+++ b/src/components/code-input/index.tsx
@@ -18,8 +18,7 @@ export interface CodeInputProps
   extends Omit<BoxProps, 'children' | 'onChange'> {
   label?: string;
   value: string;
-  // Use javascript for displaying JSON
-  mode: 'javascript' | 'yaml' | 'python' | 'sql';
+  mode: 'json' | 'javascript' | 'yaml' | 'python' | 'sql';
   width?: string | number;
   height?: string | number;
   labelAction?: React.ReactNode;


### PR DESCRIPTION
This PR adds `json` as a valid language. We used `javascript` for `json` before, but the styling in darcula mode would be different from all of the other code snippets, making it inconsistent visually.

Before: 
![image](https://user-images.githubusercontent.com/19791699/234544598-bbe6b199-4b8f-4f83-aa87-10ae521278d5.png)

After:
![image](https://user-images.githubusercontent.com/19791699/234544637-51683b44-0fc1-4400-ae49-15cb8b3f3f55.png)

Other snippets:
![image](https://user-images.githubusercontent.com/19791699/234544677-cb114ac8-67ac-4a9d-9366-2de0ea7f9025.png)


