### PR TITLE
fix: word breaks

### DIFF
--- a/src/theme-chakra/ChakraThemeProvider.tsx
+++ b/src/theme-chakra/ChakraThemeProvider.tsx
@@ -5,6 +5,13 @@ const theme = extendTheme({
   config: {
     cssVarPrefix: 'quartz',
   },
+  styles: {
+    global: {
+      '*, *::before, &::after': {
+        wordWrap: 'normal',
+      },
+    },
+  },
 });
 
 export const ChakraThemeProvider = ({ children }: PropsWithChildren) => {


### PR DESCRIPTION
Chakra has default word-breaks
as mentioned here:
https://chakra-ui.com/docs/styled-system/global-styles#default-styles

This breaks some styles on hops side.
Fixed by setting it to `normal`

### Problem
![image](https://user-images.githubusercontent.com/19791699/235706621-3bdb4b7d-0825-4900-a047-222ec4a6fb0e.png)

### Fixed
![image](https://user-images.githubusercontent.com/19791699/235706695-17ac70d9-198a-4b4b-bd72-da491b5f4ca2.png)
