### PR TITLE
style(card): add overflow-x

### DIFF
--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -9,4 +9,6 @@ export default {
   borderWidth: '1px',
   borderStyle: 'solid',
   boxSizing: 'border-box',
+
+  overflowX: 'auto',
 } as SxStyleProp;

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -9,6 +9,4 @@ export default {
   borderWidth: '1px',
   borderStyle: 'solid',
   boxSizing: 'border-box',
-
-  overflowX: 'auto',
 } as SxStyleProp;

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -72,6 +72,7 @@ const Card: FC<CardProps> = ({
           maxHeight={realHeight}
           height="100%"
           overflowY={isScrollable ? 'auto' : 'initial'}
+          overflowX="auto"
           p="20px"
           {...contentProps}
         >


### PR DESCRIPTION
Jira - https://hopsworks.atlassian.net/browse/HFRONT-704

Card would break layouts when items in it were too wide, adding an overflow solves the issue.

https://github.com/logicalclocks/quartz/assets/19791699/53039c10-4cca-457b-87ef-4e3153b3520b


