### PR TITLE
build: make ci build with node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v3
         name: Setup Node.js
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install


### PR DESCRIPTION
Bump node version from 16 to 18, it's breaking docs build.