### PR TITLE
build: use correct script for building sb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Build StoryBook🤖
         run: |
-          NODE_OPTIONS=--max_old_space_size=4096 pnpm run predeploy
+          NODE_OPTIONS=--max_old_space_size=4096 pnpm run build-storybook
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.4.3

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "test:lint": "eslint --ext .ts,.tsx ./src",
     "test:prettier": "prettier --check ./src",
     "prettier": "prettier --write ./src",
-    "predeploy": "pnpm storybook build",
     "deploy": "gh-pages -d storybook-static",
     "build-storybook": "storybook build",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
It was running `pnpm storybook predeploy` which was translated to `storybook dev -p 6006 predeploy` :D
pretty simple mistake, but took a while to realize
now it should work