### PR TITLE
feat(readonlytable): add possibility to render custom cell

### DIFF
--- a/src/components/table/read-only/dummydata.json
+++ b/src/components/table/read-only/dummydata.json
@@ -6,7 +6,7 @@
     },
     {
       "identifierName": "score",
-      "value": "1"
+      "value": "some verryyyy long text blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah"
     },
     {
       "identifierName": "dummycolumn_test1",

--- a/src/components/table/stories.tsx
+++ b/src/components/table/stories.tsx
@@ -36,12 +36,33 @@ const meta: Meta<typeof Table> = {
 };
 export default meta;
 
+const Score = ({ value, isHovered }: any) => (
+  <Box
+    sx={{
+      p: '8px',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      maxWidth: '400px',
+      ...(isHovered && {
+        overflow: 'initial',
+        whiteSpace: 'initial',
+        height: '100%',
+      }),
+    }}
+  >
+    {value}
+  </Box>
+);
+
 const headers = [
   {
     identifier: { name: 'away_team_id' },
+    cellRender: ({ value }: { value: string }) => `${value} ++`,
   },
   {
     identifier: { name: 'score' },
+    cellRender: Score,
   },
   {
     identifier: { name: 'dummycolumn_test1' },

--- a/src/components/table/type.ts
+++ b/src/components/table/type.ts
@@ -6,11 +6,14 @@ export interface TableCell {
   identifierName: string;
   value: TableCellType;
   readOnly?: boolean;
+  /* no usage just for fixing type, use `cellRender` in TableHeader props instead */
+  render?: TableHeader['cellRender'];
 }
 
 export interface TableHeader {
   identifier: ColumnIdentifier;
   headerRender?: (isOpen: boolean) => React.ReactElement;
+  cellRender?: (props: { value: any; isHovered?: boolean }) => React.ReactNode;
 }
 
 export interface ColumnIdentifier {


### PR DESCRIPTION
The custom cell accepts both the value of the cell and the boolean isHovered which is true when hovering over any of the cells in the row