### PR TITLE
docs(select): deprecate old select components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,15 @@ export {
   List,
   ListItem,
   Pagination,
+  /**
+   * @deprecated
+   * use EditableSelect or SingleSelect
+   */
   Select,
+  /**
+   * @deprecated
+   * use EditableSelect or SingleSelect
+   */
   Select2,
   EditableSelect,
   ThemeProvider,


### PR DESCRIPTION
We should use EditableSelect or SingleSelect components instead