### PR TITLE
fix: removed drop shadow on main button variants & added a pixel for border radius

### DIFF
--- a/src/components/button/styles.ts
+++ b/src/components/button/styles.ts
@@ -9,7 +9,7 @@ export const wrapper = {
   py: '8px',
   px: '15px',
 
-  borderRadius: 0,
+  borderRadius: '1px',
   boxSizing: 'border-box',
 
   fontFamily: 'label',

--- a/src/components/card/card-secondary.styles.ts
+++ b/src/components/card/card-secondary.styles.ts
@@ -32,4 +32,5 @@ export default {
   borderWidth: '1px',
   borderStyle: 'solid',
   boxSizing: 'border-box',
+  borderRadius: '1px',
 } as SxStyleProp;

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -9,4 +9,5 @@ export default {
   borderWidth: '1px',
   borderStyle: 'solid',
   boxSizing: 'border-box',
+  borderRadius: '1px',
 } as SxStyleProp;

--- a/src/components/compact-button/styles.ts
+++ b/src/components/compact-button/styles.ts
@@ -2,7 +2,7 @@ export default {
   default: {
     border: '1px solid',
     borderColor: 'grayShade3',
-    borderRadius: '2px',
+    borderRadius: '1px',
     backgroundColor: 'grayShade3',
     cursor: 'pointer',
     boxShadow: 'none',

--- a/src/components/file-button/file-button.styles.ts
+++ b/src/components/file-button/file-button.styles.ts
@@ -12,7 +12,7 @@ export const fileButton = {
 
   cursor: 'pointer',
 
-  borderRadius: 0,
+  borderRadius: '1px',
   boxSizing: 'border-box',
 
   fontFamily: 'label',

--- a/src/components/icon-button/icon-button.styles.ts
+++ b/src/components/icon-button/icon-button.styles.ts
@@ -5,4 +5,5 @@ export const wrapper = {
 
   height: '32px',
   width: '32px',
+  borderRadius: '1px',
 };

--- a/src/components/toggle-button/toggle-button.styles.ts
+++ b/src/components/toggle-button/toggle-button.styles.ts
@@ -10,7 +10,7 @@ export default {
 
     borderWidth: '1px',
     borderStyle: 'solid',
-    borderRadius: 0,
+    borderRadius: '1px',
 
     transition: 'all 0.25s ease',
 

--- a/src/theme/buttons/alert.ts
+++ b/src/theme/buttons/alert.ts
@@ -5,7 +5,7 @@ export default {
 
   borderColor: 'grayShade2',
 
-  boxShadow: 'secondary',
+  // Removed boxShadow property
 
   ':hover': {
     bg: 'labels.redShade2',

--- a/src/theme/buttons/alert.ts
+++ b/src/theme/buttons/alert.ts
@@ -5,7 +5,6 @@ export default {
 
   borderColor: 'grayShade2',
 
-  // Removed boxShadow property
 
   ':hover': {
     bg: 'labels.redShade2',

--- a/src/theme/buttons/primary.ts
+++ b/src/theme/buttons/primary.ts
@@ -6,7 +6,7 @@ export default {
   borderStyle: 'solid',
   borderColor: 'primary',
 
-  boxShadow: 'primary',
+  // Removed boxShadow property
 
   ':hover': {
     bg: 'primaryShade1',

--- a/src/theme/buttons/primary.ts
+++ b/src/theme/buttons/primary.ts
@@ -6,7 +6,6 @@ export default {
   borderStyle: 'solid',
   borderColor: 'primary',
 
-  // Removed boxShadow property
 
   ':hover': {
     bg: 'primaryShade1',

--- a/src/theme/buttons/secondary.ts
+++ b/src/theme/buttons/secondary.ts
@@ -6,7 +6,6 @@ export default {
   borderStyle: 'solid',
   borderColor: 'grayShade2',
 
-  // Removed boxShadow property
 
   ':hover': {
     bg: 'primaryShade2',

--- a/src/theme/buttons/secondary.ts
+++ b/src/theme/buttons/secondary.ts
@@ -6,7 +6,7 @@ export default {
   borderStyle: 'solid',
   borderColor: 'grayShade2',
 
-  boxShadow: 'secondary',
+  // Removed boxShadow property
 
   ':hover': {
     bg: 'primaryShade2',


### PR DESCRIPTION
This pull request standardizes the `borderRadius` property across multiple components and removes the `boxShadow` property from button themes to simplify styling and ensure consistency.

### Standardization of `borderRadius`:
* Updated `borderRadius` to `'1px'` in the following components:
  - `src/components/button/styles.ts` (`wrapper`)
  - `src/components/card/card-secondary.styles.ts`
  - `src/components/card/card.styles.ts`
  - `src/components/compact-button/styles.ts` (changed from zero to `'1px'`)
  - `src/components/file-button/file-button.styles.ts` (`fileButton`)
  - `src/components/icon-button/icon-button.styles.ts` (`wrapper`)
  - `src/components/toggle-button/toggle-button.styles.ts`

### Simplification of button theme styles:
* Removed the `boxShadow` property from the following button themes:
  - `src/theme/buttons/alert.ts`
  - `src/theme/buttons/primary.ts`
  - `src/theme/buttons/secondary.ts`