### PR TITLE
feat: add grayShade4 color to theme

### DIFF
--- a/src/theme-chakra/theme/semanticTokens.ts
+++ b/src/theme-chakra/theme/semanticTokens.ts
@@ -24,6 +24,10 @@ export const semanticTokens = {
       default: '#E2E2E2',
       _dark: '#4D4D4D',
     },
+    grayShade4: {
+      default: '#FAFAFA',
+      _dark: '#0A0A0A',
+    },
     primary: {
       default: '#21B182',
       _dark: '#229570',

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -61,6 +61,7 @@ export const colors = {
   grayShade1: '#CBCBCB',
   grayShade2: '#E2E2E2',
   grayShade3: '#F5F5F5',
+  grayShade4: '#FAFAFA',
 
   black: '#272727',
   white: '#FFFFFF',
@@ -182,6 +183,7 @@ export const darkThemeColors: ITheme['colors'] = {
   grayShade1: '#707070',
   grayShade2: '#4D4D4D',
   grayShade3: '#1e2021',
+  grayShade4: '#0A0A0A',
 
   black: '#F0F0F0',
 

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -9,6 +9,7 @@ export interface IThemeColors {
   grayShade1: string;
   grayShade2: string;
   grayShade3: string;
+  grayShade4: string;
 
   black: string;
   white: string;


### PR DESCRIPTION
- Added grayShade4 (#FAFAFA light, #0A0A0A dark) to color system
- Updated type definitions, theme.ts, and Chakra semantic tokens