### PR TITLE
feat(datepicker): add editable mode

### DIFF
--- a/src/components/datepicker/datepicker.styles.ts
+++ b/src/components/datepicker/datepicker.styles.ts
@@ -24,9 +24,8 @@ export default {
     outline: 'none',
   },
 
-  '.react-datepicker__input-container input': {
-    width: '50px',
-    visibility: 'hidden',
+  'input:focus': {
+    backgroundColor: 'primaryShade2',
   },
 
   '.react-datepicker__triangle': {
@@ -94,10 +93,15 @@ export default {
     {
       color: 'black',
     },
-  '.react-datepicker__day--disabled, react-datepicker__day--excluded, .react-datepicker__day--disabled: hover':
+  '.react-datepicker__day--disabled, .react-datepicker__day--excluded, .react-datepicker__day--disabled:hover':
     {
       color: 'grayShade1',
       cursor: 'not-allowed',
+    },
+  '.react-datepicker__day--in-range.react-datepicker__day--disabled, .react-datepicker__day--in-range.react-datepicker__day--excluded':
+    {
+      backgroundColor: 'grayShade3',
+      color: 'grayShade1',
     },
 
   '': {

--- a/src/components/datepicker/index.tsx
+++ b/src/components/datepicker/index.tsx
@@ -13,6 +13,7 @@ import styles from './datepicker.styles';
 export interface DatePickerProps extends ReactDatePickerProps {
   selectProps: Pick<SelectProps, 'variant' | 'noDataMessage' | 'value'>;
   datePickerAlign?: 'left' | 'right';
+  editable?: boolean;
   sx?: SxStyleProp;
 }
 
@@ -22,6 +23,7 @@ const getPlacement = (align: DatePickerProps['datePickerAlign']) =>
 const DatePicker = ({
   selectProps,
   datePickerAlign = 'right',
+  editable = false,
   sx,
   ...props
 }: DatePickerProps) => {
@@ -33,7 +35,13 @@ const DatePicker = ({
         onCalendarClose={() => setOpen(false)}
         shouldCloseOnSelect
         {...props}
-        customInput={<DateSelect isOpen={isOpen} selectProps={selectProps} />}
+        customInput={
+          <DateSelect
+            isOpen={isOpen}
+            selectProps={selectProps}
+            editable={editable}
+          />
+        }
         popperPlacement={getPlacement(datePickerAlign)}
       />
     </Flex>
@@ -43,7 +51,7 @@ const DatePicker = ({
 export default memo(DatePicker);
 
 const DateSelect = forwardRef(
-  ({ value, selectProps, isOpen, ...props }: any, ref: any) => (
+  ({ value, selectProps, isOpen, editable, onChange, ...props }: any, ref: any) => (
     <Flex
       ref={ref}
       alignItems="center"
@@ -68,14 +76,32 @@ const DateSelect = forwardRef(
         </Labeling>
       )}
 
-      <Value
-        mr="5px"
-        sx={{ fontSize: 'text', fontWeight: 'text', fontFamily: 'text' }}
-        flexGrow={1}
-        flexShrink={0}
-      >
-        {selectProps?.value ?? value}
-      </Value>
+      {editable ? (
+        <input
+          value={value ?? ''}
+          onChange={onChange}
+          style={{
+            flexGrow: 1,
+            minWidth: '175px',
+            marginRight: '5px',
+            border: 'none',
+            outline: 'none',
+            fontFamily: 'Inter',
+            fontSize: '12px',
+            fontWeight: 500,
+            color: '#272727',
+          }}
+        />
+      ) : (
+        <Value
+          mr="5px"
+          sx={{ fontSize: 'text', fontWeight: 'text', fontFamily: 'text' }}
+          flexGrow={1}
+          flexShrink={0}
+        >
+          {selectProps?.value ?? value}
+        </Value>
+      )}
       <GetIcon flexShrink={0} icon={IconName.arrow_up_down} size="sm" />
     </Flex>
   ),

--- a/src/components/datepicker/stories.tsx
+++ b/src/components/datepicker/stories.tsx
@@ -18,6 +18,7 @@ export const DatePicker: StoryObj<typeof DatePickerComponent> = {
     showTimeSelect: true,
     dateFormat: DATE_TIME.DATE_TIME_FULL_MONTH,
     excludeTimes: [new Date()],
+    editable: true,
   },
   render: ({ selectProps, ...restProps }) => {
     const [startDate, setStartDate] = useState(new Date('2024-02-20T16:24:00'));


### PR DESCRIPTION
## Summary
- Add `editable` prop for inline date text editing
- Fix unreadable disabled days in date range (gray bg)
- Add focus highlight on input

🤖 Generated with [Claude Code](https://claude.com/claude-code)